### PR TITLE
Add session types

### DIFF
--- a/app/controllers/organizer/session_types_controller.rb
+++ b/app/controllers/organizer/session_types_controller.rb
@@ -1,0 +1,59 @@
+class Organizer::SessionTypesController < Organizer::ApplicationController
+  before_action :set_session_type, only: [:edit, :update, :destroy]
+
+  def index
+    @session_types = @event.session_types
+  end
+
+  def new
+    @session_type = SessionType.new(public: true)
+  end
+
+  def edit
+
+  end
+
+  def create
+    @session_type = @event.session_types.build(session_type_params)
+
+    if @session_type.save
+      flash[:info] = 'Session type created.'
+      redirect_to organizer_event_session_types_path(@event)
+    else
+      flash[:danger] = 'Unable to create session type.'
+      render :new
+    end
+  end
+
+  def update
+    if @session_type.update_attributes(session_type_params)
+      flash[:info] = 'Session type updated.'
+      redirect_to organizer_event_session_types_path(@event)
+    else
+      flash[:danger] = 'Unable to update session type.'
+      render :edit
+    end
+  end
+
+  def destroy
+    if @session_type.destroy
+      flash[:info] = 'Session type destroyed.'
+    else
+      flash[:danger] = 'Unable to destroy session type.'
+    end
+
+    redirect_to organizer_event_session_types_path(@event)
+  end
+
+  private
+
+  def set_session_type
+    @session_type = @event.session_types.find(params[:id])
+  end
+
+  def session_type_params
+    params.require(:session_type)
+        .permit(:id, :name, :description, :event_id, :duration, :public)
+  end
+
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -9,6 +9,7 @@ class Event < ActiveRecord::Base
   has_many :rooms, dependent: :destroy
   has_many :tracks, dependent: :destroy
   has_many :sessions, dependent: :destroy
+  has_many :session_types, dependent: :destroy
   has_many :taggings, through: :proposals
   has_many :ratings, through: :proposals
   has_many :participant_invitations

--- a/app/models/session_type.rb
+++ b/app/models/session_type.rb
@@ -1,0 +1,31 @@
+class SessionType < ActiveRecord::Base
+  belongs_to :event
+  has_many :sessions
+
+  validates_presence_of :name, :event
+  validates_uniqueness_of :name, scope: :event
+
+  scope :sort_by_name, ->{ order(:name) }
+end
+
+# == Schema Information
+#
+# Table name: session_types
+#
+#  id          :integer          not null, primary key
+#  name        :string
+#  description :string
+#  duration    :integer
+#  public      :boolean          default(TRUE)
+#  event_id    :integer
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+# Indexes
+#
+#  index_session_types_on_event_id  (event_id)
+#
+# Foreign Keys
+#
+#  fk_rails_e67735874a  (event_id => events.id)
+#

--- a/app/views/organizer/events/show.html.haml
+++ b/app/views/organizer/events/show.html.haml
@@ -26,6 +26,9 @@
             = event.guidelines.truncate(150, separator: /\s/)
           = link_to "Public guidelines", event_path(slug: event.slug)
           %p= link_to "Edit Guidelines", edit_organizer_event_path(:form => "guidelines_form"), class: "btn btn-primary"
+        %dt Session Types:
+        %dd
+          %p= link_to "Edit Session Types", organizer_event_session_types_path(event), class: "btn btn-primary"
       %dl.dl-horizontal
         %dt CFP Opens:
         %dd= event.cfp_opens

--- a/app/views/organizer/session_types/_form.html.haml
+++ b/app/views/organizer/session_types/_form.html.haml
@@ -1,0 +1,16 @@
+.form-group
+  = f.label :name
+  = f.text_field :name, class: 'form-control', placeholder: 'Name'
+  .form-group
+    = f.label :description
+    = f.text_area :description, class: 'form-control', placeholder: 'Description', rows: 6
+  .form-group
+    = f.label :duration
+    = f.text_field :duration, type: 'number', class: 'form-control', placeholder: '#'
+  %p.help-block How long the session will be (in minutes).
+  .form-group
+    = f.label 'Visibility'
+    %br
+    = f.check_box :public?, class: ''
+    &nbsp; make public
+  %p.help-block If checked, speakers will be able to select this session type when submitting proposals.

--- a/app/views/organizer/session_types/_session_types_form.html.haml
+++ b/app/views/organizer/session_types/_session_types_form.html.haml
@@ -1,0 +1,11 @@
+%h2 Tags
+.form-group
+  = f.label :valid_proposal_tags
+  = f.text_field :valid_proposal_tags, class: 'form-control', placeholder: 'Separate multiple tags with commas'
+  %p.help-block This is a comma separated list of tags allowed for use on proposals. These limits apply to publicly displayed tags and not to tags used internally by reviewers.
+
+.form-group
+  = f.label :valid_review_tags
+  = f.text_field :valid_review_tags, class: 'form-control', placeholder: 'Separate multiple tags with commas'
+  %p.help-block This is a comma separated list of tags allowed for use during proposal reviews. These limits apply to tags used internally by reviewers and not to publicly displayed tags.
+  %button.pull-right.btn.btn-success{:type => "submit"} Save

--- a/app/views/organizer/session_types/edit.html.haml
+++ b/app/views/organizer/session_types/edit.html.haml
@@ -1,0 +1,6 @@
+.row
+  %fieldset.col-md-6
+    %h2 New Session Type
+    = form_for @session_type, url: organizer_event_session_type_path(@event, @session_type), html: {method: 'patch', role: 'form'} do |f|
+      = render partial: 'form', locals: {f: f}
+      %button.btn.btn-success{type: 'submit'} Update

--- a/app/views/organizer/session_types/index.html.haml
+++ b/app/views/organizer/session_types/index.html.haml
@@ -1,0 +1,25 @@
+.row
+  %h1 Event Session Types
+  - if @session_types.any?
+    %table.table.table-striped
+      %thead
+        %tr
+          %th Name
+          %th Description
+          %th Duration
+          %th Public
+          %th{colspan: '2'}
+      %tbody
+        - @session_types.each do |st|
+          %tr
+            %td= st.name
+            %td= truncate(st.description, length: 80)
+            %td= st.duration
+            %td= 'X' if st.public?
+            %td.action-edit= link_to 'Edit', edit_organizer_event_session_type_path(@event, st)
+            %td.action-destroy= link_to 'Destroy', organizer_event_session_type_path(@event, st), method: :delete, data: { confirm: 'Are you sure?' }
+  -else
+    %p No session types defined for this event.
+
+  %br
+  %span.action-new= link_to 'New', new_organizer_event_session_type_path(@event)

--- a/app/views/organizer/session_types/new.html.haml
+++ b/app/views/organizer/session_types/new.html.haml
@@ -1,0 +1,6 @@
+.row
+  %fieldset.col-md-6
+    %h2 New Session Type
+    = form_for @session_type, url: organizer_event_session_types_path(@event), html: {method: 'post', role: 'form'} do |f|
+      = render partial: 'form', locals: {f: f}
+      %button.btn.btn-success{type: 'submit'} Save

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -81,6 +81,7 @@ Rails.application.routes.draw do
       resources :rooms, only: [:create, :update, :destroy]
       resources :tracks, only: [:create, :destroy]
       resources :sessions, except: :show
+      resources :session_types, except: :show
       resources :proposals, param: :uuid do
         resources :speakers, only: [:new, :create]
         post :finalize

--- a/db/migrate/20160614162404_create_session_types.rb
+++ b/db/migrate/20160614162404_create_session_types.rb
@@ -1,0 +1,13 @@
+class CreateSessionTypes < ActiveRecord::Migration
+  def change
+    create_table :session_types do |t|
+      t.string :name
+      t.string :description
+      t.integer :duration
+      t.boolean :public, default: true
+      t.references :event, index: true
+      t.timestamps null: false
+    end
+    add_foreign_key :session_types, :events
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160612190544) do
+ActiveRecord::Schema.define(version: 20160614162404) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -160,6 +160,18 @@ ActiveRecord::Schema.define(version: 20160612190544) do
 
   add_index "services", ["user_id"], name: "index_services_on_user_id", using: :btree
 
+  create_table "session_types", force: :cascade do |t|
+    t.string   "name"
+    t.string   "description"
+    t.integer  "duration"
+    t.boolean  "public",      default: true
+    t.integer  "event_id"
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
+  end
+
+  add_index "session_types", ["event_id"], name: "index_session_types_on_event_id", using: :btree
+
   create_table "sessions", force: :cascade do |t|
     t.integer  "conference_day"
     t.time     "start_time"
@@ -230,4 +242,5 @@ ActiveRecord::Schema.define(version: 20160612190544) do
 
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
 
+  add_foreign_key "session_types", "events"
 end


### PR DESCRIPTION
Giving organizers the ability to define session types for an event. Name, description, duration, public/private.
