### PR TITLE
42 streamline nav

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,7 @@ class ApplicationController < ActionController::Base
 
   helper_method :user_signed_in?
   helper_method :reviewer?
+  helper_method :organizer?
 
   layout 'application'
   decorates_assigned :event
@@ -14,6 +15,10 @@ class ApplicationController < ActionController::Base
 
   def reviewer?
     @is_reviewer ||= current_user.reviewer?
+  end
+
+  def organizer?
+    @is_organizer ||= current_user.organizer?
   end
 
   def user_signed_in?

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -4,9 +4,9 @@ class HomeController < ApplicationController
   # - the currently live event guidelines page, or
   # - /events if no current event
   def show
-    @event = Event.live.first
-    if @event
-      redirect_to event_url(@event.slug)
+    live_events = Event.live.all
+    if live_events.count == 1
+      redirect_to event_url(live_events.first.slug)
     else
       redirect_to events_url
     end

--- a/app/controllers/reviewer/events_controller.rb
+++ b/app/controllers/reviewer/events_controller.rb
@@ -4,6 +4,7 @@ class Reviewer::EventsController < Reviewer::ApplicationController
   def show
     participant = Participant.find_by(user_id: current_user)
     rating_counts = @event.ratings.group(:user_id).count
+
     render locals: {
              event: @event.decorate,
              rating_counts: rating_counts,

--- a/app/controllers/speakers_controller.rb
+++ b/app/controllers/speakers_controller.rb
@@ -1,8 +1,6 @@
 class SpeakersController < ApplicationController
   before_filter :require_user
 
-
-
   def destroy
     speaker = Speaker.find_by!(id: params[:id])
 

--- a/app/views/admin/events/index.html.haml
+++ b/app/views/admin/events/index.html.haml
@@ -27,6 +27,3 @@
               %td= link_to "Archive", admin_event_archive_path(event), method: :post, class: "btn btn-danger btn-xs", data: {confirm: "This will hide this event from reviewers and organizers. Would you like to continue?" }
             - else
               %td= link_to "Unarchive", admin_event_unarchive_path(event), method: :post, class: "btn btn-success btn-xs"
-
-
-

--- a/app/views/events/index.html.haml
+++ b/app/views/events/index.html.haml
@@ -1,6 +1,11 @@
 - events.each do |event|
   .event
     %h1
-      = event
+      - if current_user && current_user.organizer?
+        = link_to(event, organizer_event_path(event))
+      - elsif current_user && current_user.reviewer?
+        = link_to(event, reviewer_event_path(event))
+      - elsif current_user
+        = link_to(event, event_path(event.slug))
       %small= event.status
     = event.path_for(current_user)

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -1,7 +1,7 @@
 .row
   .col-md-11
     %h1
-      = event
+      = link_to(event, event_path(event.slug))
       %small= event.status
   .col-md-1
     .share.pull-right= event.tweet_button

--- a/app/views/layouts/_navbar.html.haml
+++ b/app/views/layouts/_navbar.html.haml
@@ -1,0 +1,53 @@
+.navbar.navbar-inverse.navbar-fixed-top
+  .container
+    .navbar-header
+      %button.navbar-toggle{ type: "button", data: { toggle: "collapse", target: ".navbar-collapse" } }
+        %span.icon-bar
+        %span.icon-bar
+        %span.icon-bar
+      - if event && event.slug
+        = link_to event.name, event_path(slug: event.slug), class: 'navbar-brand'
+      - else
+        = link_to "#{Rails.application.class.parent_name}", events_path, class: 'navbar-brand'
+
+    .collapse.navbar-collapse
+      %ul.nav.navbar-nav
+      - if user_signed_in?
+        %ul.nav.navbar-nav.navbar-right
+          - if current_user.proposals.any?
+            %li= link_to "My Proposals", proposals_path
+
+          - if current_user.reviewer? && event
+            - if event.id != nil
+              - unless event.archived?
+                %li= link_to "Review Proposals", reviewer_event_proposals_path(event.id)
+
+          - if current_user.organizer? && event
+            - if event.id != nil
+              - unless event.archived?
+                %li= link_to "Organize Proposals", organizer_event_proposals_path(event)
+                %li= link_to "Program", organizer_event_program_path(event)
+                %li= link_to "Schedule", organizer_event_sessions_path(event)
+
+          %li= link_to "Notifications", notifications_path
+
+          %li.dropdown
+            - unless current_user.demographics_complete?
+              #gravatar-alert-container
+                = link_to edit_profile_path, {id: "gravatar-alert", data: {toggle: "tooltip", placement: "bottom"}, title: "Click here to finish filling out your demographics information" } do
+                  %span.glyphicon.glyphicon-exclamation-sign
+            %a.dropdown-toggle.gravatar-container{ href: "#", data: { toggle: "dropdown" } }
+              = image_tag("https://www.gravatar.com/avatar/#{current_user.gravatar_hash}?s=25", class: 'user-dropdown-gravatar')
+              &nbsp; #{current_user.name}
+              %b.caret
+            %ul.dropdown-menu
+              %li= link_to "My Profile", edit_profile_path
+              %li= link_to "Sign Out", destroy_user_session_path, method: :delete
+              - if current_user && current_user.admin?
+                %li.divider
+                %li= link_to "Users", admin_users_path
+                %li= link_to "Manage Events", admin_events_path
+
+      - else
+        %ul.nav.navbar-nav.navbar-right
+          %li= link_to "Log in", new_user_session_path

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -6,103 +6,17 @@
 
     = stylesheet_link_tag 'application', media: 'all'
     = javascript_include_tag 'application'
-
     = javascript_include_tag "//www.google.com/jsapi", "chartkick"
-
     = javascript_tag { yield :custom_js }
-
     = csrf_meta_tags
 
     // html5 shim and respond.js ie8 support of html5 elements and media queries
     /[if lt ie 9]
       = javascript_include_tag "/js/html5shiv.js"
       = javascript_include_tag "/js/respond.min.js"
+
   %body
-    .navbar.navbar-inverse.navbar-fixed-top
-      .container
-        .navbar-header
-          %button.navbar-toggle{ type: "button", data: { toggle: "collapse", target: ".navbar-collapse" } }
-            %span.icon-bar
-            %span.icon-bar
-            %span.icon-bar
-          - if event && event.slug
-            = link_to event.name, event_path(slug: event.slug), class: 'navbar-brand'
-          - else
-            = link_to "#{Rails.application.class.parent_name}", events_path, class: 'navbar-brand'
-
-        .collapse.navbar-collapse
-          %ul.nav.navbar-nav
-          - if user_signed_in?
-            %ul.nav.navbar-nav.navbar-right
-              - if current_user.proposals
-                %li.dropdown
-                  %a.dropdown-toggle{ href: "#", data: {toggle: "dropdown"} }
-                    Speaking
-                    %b.caret
-                  %ul.dropdown-menu
-                    %li= link_to "My Proposals", proposals_path
-              - if current_user.reviewer?
-                %li.dropdown
-                  %a.review_nav.dropdown-toggle{ href: "#", data: {toggle: "dropdown"} }
-                    Review
-                    %b.caret
-                  %ul.dropdown-menu
-                    - current_user.reviewer_events.each do |event|
-                      -unless event.archived?
-                        -if current_user.organizer_for_event?(event)
-                          %li= link_to event, reviewer_event_proposals_path(event)
-                        - else
-                          %li= link_to event, reviewer_event_path(event)
-                          %ul
-                            %li= link_to 'Proposals', reviewer_event_proposals_path(event)
-              - if current_user.organizer?
-                %li.dropdown
-                  %a.organize_nav.dropdown-toggle{ href: "#", data: {toggle: "dropdown"} }
-                    Organize
-                    %b.caret
-                  %ul.dropdown-menu
-                    - current_user.organizer_events.each do |event|
-                      %li
-                        -unless event.archived?
-                          = link_to event, organizer_event_path(event)
-                          %ul
-                            %li= link_to 'Proposals', organizer_event_proposals_path(event)
-                            %li= link_to 'Program', organizer_event_program_path(event)
-                            %li= link_to "Schedule", organizer_event_sessions_path(event)
-              %li.dropdown
-                %a.dropdown-toggle{ href: "#", data: { toggle: "dropdown" } }
-                  Notifications
-                  - if current_user.notifications.unread.count > 0
-                    %span.badge.badge-important
-                      #{current_user.notifications.unread.count}
-                  %b.caret
-                %ul.dropdown-menu
-                  - current_user.notifications.recent.each do |notification|
-                    %li= link_to notification.message, notification_path(notification)
-                    %li.divider
-                  %li.text-right= link_to 'Mark all as read', mark_all_as_read_notifications_path, method: :post
-                  %li.text-right= link_to 'View all notifications', notifications_path
-
-              %li.dropdown
-                - unless current_user.demographics_complete?
-                  #gravatar-alert-container
-                    = link_to edit_profile_path, {id: "gravatar-alert", data: {toggle: "tooltip", placement: "bottom"}, title: "Click here to finish filling out your demographics information" } do
-                      %span.glyphicon.glyphicon-exclamation-sign
-                %a.dropdown-toggle.gravatar-container{ href: "#", data: { toggle: "dropdown" } }
-                  = image_tag("https://www.gravatar.com/avatar/#{current_user.gravatar_hash}?s=25", class: 'user-dropdown-gravatar')
-                  &nbsp; #{current_user.name}
-                  %b.caret
-                %ul.dropdown-menu
-                  %li= link_to 'My Profile', edit_profile_path
-                  %li= link_to 'Sign Out', destroy_user_session_path, method: :delete
-                  - if current_user && current_user.admin?
-                    %li.divider
-                    %li= link_to 'Users', admin_users_path
-                    %li= link_to 'Manage Events', admin_events_path
-
-          - else
-            %ul.nav.navbar-nav.navbar-right
-              %li= link_to 'Log in', new_user_session_path
+    = render partial: "layouts/navbar"
 
   - if on_organizer_page?
     .alert-viewer-mode

--- a/spec/features/current_event_user_flow_spec.rb
+++ b/spec/features/current_event_user_flow_spec.rb
@@ -1,0 +1,269 @@
+require 'rails_helper'
+
+feature "A user sees correct information for the current event and their role" do
+  let!(:normal_user) { create(:user) }
+  let!(:reviewer_user) { create(:user) }
+  let!(:organizer_user) { create(:user) }
+  let!(:admin_user) { create(:user, admin: true) }
+
+  scenario "When there are multiple live events the root is /events" do
+    create(:event, state: "open")
+    create(:event, state: "open")
+
+    visit root_path
+    expect(current_path).to eq(events_path)
+  end
+
+  scenario "User flow for a speaker when there is one live event" do
+    event_1 = create(:event, state: "open")
+    event_2 = create(:event, state: "closed")
+
+    signin(normal_user.email, normal_user.password)
+
+    within ".navbar" do
+      expect(page).to have_link(event_1.name)
+      expect(page).to have_link("Notifications")
+      expect(page).to have_link(normal_user.name)
+    end
+
+    expect(current_path).to eq(event_path(event_1.slug))
+
+    expect(page).to have_link(event_1.name)
+    expect(page).to_not have_link(event_2.name)
+
+    find("h1").click
+    expect(current_path).to eq(event_path(event_1.slug))
+    within ".navbar" do
+      expect(page).to have_content(event_1.name)
+      expect(page).to have_content("Notifications")
+      expect(page).to have_content(normal_user.name)
+      expect(page).to_not have_content("My Proposals")
+    end
+
+    proposal = create(:proposal, :with_speaker)
+    normal_user.proposals << proposal
+    visit root_path
+    expect(page).to have_content("My Proposals")
+  end
+
+  scenario "User flow for a speaker when there is no live event" do
+    event_1 = create(:event, state: "closed")
+    event_2 = create(:event, state: "closed")
+    proposal = create(:proposal, :with_speaker)
+
+    signin(normal_user.email, normal_user.password)
+
+    within ".navbar" do
+      expect(page).to have_content("CFPApp")
+      expect(page).to have_link("Notifications")
+      expect(page).to have_link(normal_user.name)
+    end
+
+    expect(current_path).to eq(events_path)
+
+    expect(page).to have_link(event_1.name)
+    expect(page).to have_link(event_2.name)
+
+    click_on event_2.name
+    expect(current_path).to eq(event_path(event_2.slug))
+    within ".navbar" do
+      expect(page).to have_content(event_2.name)
+      expect(page).to have_content("Notifications")
+      expect(page).to have_content(normal_user.name)
+      expect(page).to_not have_content("My Proposals")
+    end
+
+    normal_user.proposals << proposal
+    visit root_path
+    within ".navbar" do
+      expect(page).to have_content("My Proposals")
+    end
+  end
+
+  scenario "User flow and navbar layout for a reviewer" do
+    event_1 = create(:event, state: "open")
+    event_2 = create(:event, state: "open")
+    proposal = create(:proposal, :with_reviewer_public_comment)
+    create(:participant, :reviewer, user: reviewer_user, event: event_1)
+    create(:participant, :reviewer, user: reviewer_user, event: event_2)
+
+    signin(reviewer_user.email, reviewer_user.password)
+
+    click_on(event_1.name)
+
+    within ".navbar" do
+      expect(page).to have_content(event_1.name)
+      expect(page).to have_content("Review Proposals")
+      expect(page).to have_link("Notifications")
+      expect(page).to have_link(reviewer_user.name)
+      expect(page).to_not have_link("My Proposals")
+    end
+
+    reviewer_user.proposals << proposal
+    visit event_path(event_2.slug)
+
+    within ".navbar" do
+      expect(page).to have_content("My Proposals")
+      expect(page).to have_content("Review Proposals")
+    end
+
+    visit event_path(event_1.slug)
+
+    within ".navbar" do
+      expect(page).to have_content("My Proposals")
+      expect(page).to have_content("Review Proposals")
+    end
+
+    click_on("Review Proposals")
+    expect(page).to have_content(event_1.name)
+    expect(current_path).to eq(reviewer_event_proposals_path(event_1.id))
+  end
+
+  scenario "User flow for an organizer" do
+    event_1 = create(:event, state: "open")
+    event_2 = create(:event, state: "closed")
+    proposal = create(:proposal, :with_organizer_public_comment)
+    create(:participant, :organizer, user: organizer_user, event: event_1)
+    create(:participant, :organizer, user: organizer_user, event: event_2)
+
+    signin(organizer_user.email, organizer_user.password)
+
+    find("h1").click
+
+    within ".navbar" do
+      expect(page).to have_content(event_1.name)
+      expect(page).to have_content("Review Proposals")
+      expect(page).to have_content("Organize Proposals")
+      expect(page).to have_content("Program")
+      expect(page).to have_content("Schedule")
+      expect(page).to have_link("Notifications")
+      expect(page).to have_link(reviewer_user.name)
+      expect(page).to_not have_link("My Proposals")
+    end
+
+    organizer_user.proposals << proposal
+    visit event_path(event_2.slug)
+
+    within ".navbar" do
+      expect(page).to have_content("My Proposals")
+      expect(page).to have_content("Review Proposals")
+      expect(page).to have_content("Organize Proposals")
+      expect(page).to have_content("Program")
+      expect(page).to have_content("Schedule")
+      expect(page).to have_link("Notifications")
+    end
+
+    visit event_path(event_1.slug)
+
+    within ".navbar" do
+      expect(page).to have_content("My Proposals")
+      expect(page).to have_content("Review Proposals")
+      expect(page).to have_content("Organize Proposals")
+      expect(page).to have_content("Program")
+      expect(page).to have_content("Schedule")
+      expect(page).to have_link("Notifications")
+    end
+
+    click_on("Organize Proposals")
+    expect(page).to have_content(event_1.name)
+    expect(current_path).to eq(organizer_event_proposals_path(event_1.id))
+  end
+
+  scenario "User flow for an admin" do
+    event_1 = create(:event, state: "open")
+    event_2 = create(:event, state: "closed")
+    proposal = create(:proposal, :with_organizer_public_comment)
+    create(:participant, :organizer, user: admin_user, event: event_1)
+    create(:participant, :organizer, user: admin_user, event: event_2)
+
+    signin(admin_user.email, admin_user.password)
+
+    find("h1").click
+
+    within ".navbar" do
+      expect(page).to have_content(event_1.name)
+      expect(page).to have_content("Review Proposals")
+      expect(page).to have_content("Organize Proposals")
+      expect(page).to have_content("Program")
+      expect(page).to have_content("Schedule")
+      expect(page).to have_link("Notifications")
+      expect(page).to have_link(reviewer_user.name)
+      expect(page).to_not have_link("My Proposals")
+    end
+
+    admin_user.proposals << proposal
+    visit event_path(event_2.slug)
+
+    within ".navbar" do
+      expect(page).to have_content("My Proposals")
+      expect(page).to have_content("Review Proposals")
+      expect(page).to have_content("Organize Proposals")
+      expect(page).to have_content("Program")
+      expect(page).to have_content("Schedule")
+      expect(page).to have_link("Notifications")
+    end
+
+    visit event_path(event_1.slug)
+
+    within ".navbar" do
+      expect(page).to have_content("My Proposals")
+      expect(page).to have_content("Review Proposals")
+      expect(page).to have_content("Organize Proposals")
+      expect(page).to have_content("Program")
+      expect(page).to have_content("Schedule")
+      expect(page).to have_link("Notifications")
+    end
+
+    click_on("Organize Proposals")
+    expect(page).to have_content(event_1.name)
+    expect(current_path).to eq(organizer_event_proposals_path(event_1.id))
+
+    within ".navbar" do
+      click_on("Program")
+    end
+    expect(page).to have_content(event_1.name)
+    expect(current_path).to eq(organizer_event_program_path(event_1.id))
+
+    visit "/events"
+    click_on(event_2.name)
+
+    within ".navbar" do
+      click_on("Schedule")
+    end
+    expect(page).to have_content(event_2.name)
+    expect(current_path).to eq(organizer_event_sessions_path(event_2.id))
+
+    click_link admin_user.name
+    click_link "Users"
+    expect(current_path).to eq(admin_users_path)
+
+    visit root_path
+    click_link admin_user.name
+    click_link "Manage Events"
+    expect(current_path).to eq(admin_events_path)
+
+    within ".table" do
+      expect(page).to have_content(event_1.name)
+      expect(page).to have_content("open")
+
+      expect(page).to have_content(event_2.name)
+      expect(page).to have_content("closed")
+
+      first(:link, "Archive").click
+    end
+
+    expect(page).to have_content("#{event_1.name} is now archived.")
+    expect(page).to have_link("Unarchive")
+
+    within ".table" do
+      click_on event_1.name
+    end
+
+    within ".navbar" do
+      expect(page).to_not have_content("Review Proposals")
+      expect(page).to_not have_content("Organize Proposals")
+      expect(page).to_not have_content("Program")
+      expect(page).to_not have_content("Schedule")
+    end
+  end
+end

--- a/spec/features/participant_invitation_spec.rb
+++ b/spec/features/participant_invitation_spec.rb
@@ -11,7 +11,7 @@ feature 'Participant Invitations' do
     it "can accept the invitation" do
       visit accept_participant_invitation_path(invitation.slug, invitation.token)
       expect(page).to have_text('You successfully accepted the invitation')
-      expect(page).to have_text('Organize')
+      expect(page).to have_text('0 proposals')
     end
 
     context "User receives incorrect or missing link in participant invitation email" do

--- a/spec/features/profile_spec.rb
+++ b/spec/features/profile_spec.rb
@@ -12,7 +12,6 @@ feature 'User Profile' do
 
   before { login_as(user) }
 
-
   scenario "A user can save demographics info" do
     visit(edit_profile_path)
     select_demographics(gender: 'female', ethnicity: 'Asian', country: 'Albania')


### PR DESCRIPTION
This pull request streamlines the navbar, removing all dropdowns so that a user can get most anywhere in the app with a single click and scoping the navbar to a single event. A test suite for this flow is included.

At this juncture there is not implementation for a current_event session because it seemed unnecessary. The way the routes and controllers are set up, almost every view goes through a specific EventController, thus scoping to a single event. A tiny bit of extra conditional logic was added in the navbar partial for the one case I found where this isn't true (when an admin clicks on "Manage Events").

Includes a small refactor in the HomeController so that instead of just showing a first live event if there are live events, we default to the current live event if there is only one, otherwise we show all events so the user can choose which event to view.
