### PR TITLE
#60 Validations upon opening an event

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -51,7 +51,11 @@ class ApplicationController < ActionController::Base
   end
 
   def event_params
-    params.require(:event).permit(:name, :contact_email, :slug, :url, :valid_proposal_tags, :valid_review_tags, :custom_fields_string, :state, :guidelines, :closes_at, :speaker_notification_emails, :accept, :reject, :waitlist, :opens_at, :start_date, :end_date)
+    params.require(:event).permit(
+        :name, :contact_email, :slug, :url, :valid_proposal_tags,
+        :valid_review_tags, :custom_fields_string, :state, :guidelines,
+        :closes_at, :speaker_notification_emails, :accept, :reject,
+        :waitlist, :opens_at, :start_date, :end_date)
   end
 
   def set_event

--- a/app/views/staff/events/edit.html.haml
+++ b/app/views/staff/events/edit.html.haml
@@ -6,6 +6,7 @@
 
 .row
   .col-md-12
+    %span.required_notification * Required
     = simple_form_for event, url: event_staff_update_path(event), html: {role: 'form'} do |f|
       = render partial: "admin/events/form", locals: {f: f}
       = render partial: "admin/events/tags_form", locals: {f: f}

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -26,7 +26,13 @@ seed_event = Event.create(name: "SeedConf", slug: "seedconf", contact_email: "in
 
 
 # session types
+short_session_type = seed_event.public_session_types.create(name: 'Short Talk', duration: 40, description: 'Kinda short! Talk fast. Talk hard.')
+long_session_type = seed_event.public_session_types.create(name: 'Long Talk', duration: 120, description: 'Longer talk allows a speaker put more space in between words, hand motions.')
+internal_session_type = seed_event.session_types.create(name: 'Beenote', public: false, duration: 180, description: 'Involves live bees.')
+
 # tracks
+best_track = seed_event.tracks.create(name: 'Best Track', description: 'Better than all the other tracks.', guidelines: 'Watch yourself. Watch everybody else. All of us are winners in the best track.')
+
 # rooms
 
 


### PR DESCRIPTION
- Added session types and tracks to seed data.
- Added update-only validations to event model for guidelines and session
  types when status set to open.
- Fixed bug on event edit form when validations fail (moved partial-selection
  logic out of controller into helper).
