### PR TITLE
Improves usability of new event form.

### DIFF
--- a/app/assets/stylesheets/modules/_forms.css.scss
+++ b/app/assets/stylesheets/modules/_forms.css.scss
@@ -15,7 +15,7 @@
   .form-control {
     background-color: #edd1d1;
   }
-  label {
+  label, .help-block {
     color: darken(#edd1d1, 50%);
   }
 }
@@ -24,4 +24,18 @@
   border-top: 1px solid #ccc;
   margin: 1em 0 5em;
   padding-top: 1em;
+}
+
+input.required {
+  border: 1px solid darken(#edd1d1, 50%);
+}
+
+.required_notification {
+  color:darken(#edd1d1, 50%);
+  font-style: italic;
+  float:right;
+}
+
+span[title="required"] {
+  color: darken(#edd1d1, 50%);
 }

--- a/app/views/admin/events/_form.html.haml
+++ b/app/views/admin/events/_form.html.haml
@@ -1,46 +1,36 @@
 .row
   %fieldset.col-md-6
     %h2 Event Information
-    .form-group
-      = f.label :name
-      = f.text_field :name, class: 'form-control', placeholder: 'Name of the event'
-    .form-group
-      = f.label :contact_email
-      = f.text_field :contact_email, class: 'form-control', placeholder: 'Event email'
-    .form-group
-      = f.label :slug
-      = f.text_field :slug, class: 'form-control', placeholder: 'Slug for the event URL, may be left blank'
-      %p.help-block The slug will be used in public facing URLs. If you leave this field blank, a slug will be generated based on the name.
-    .form-group
-      = f.label :url
-      = f.text_field :url, class: 'form-control', placeholder: 'Event\'s URL'
+    = f.input :name, placeholder: 'Name of the event'
+    = f.input :slug, placeholder: 'Slug for the event URL, may be left blank once event name is filled out',
+      hint: "The slug will be used in public facing URLs. If you leave this field blank, a slug will be generated based on the name."
+    = f.input :url, label: "URL", placeholder: 'Event\'s URL'
+    = f.input :contact_email, class: 'form-control', placeholder: 'Event email'
   %fieldset.col-md-6
     %h3 CFP Dates
     .form-group.form-inline
       = f.label :opens_at
       = f.object.cfp_opens
       = f.text_field :opens_at, class: 'form-control', value: (f.object.opens_at.blank? ? "" : f.object.opens_at.to_s(:long_with_zone) )
-      -#%p.help-block Open proposal end date is optional. If you do not provide one the CFP will defer to its state.
+      %p.help-block Optional. You can manually open the CFP when ready.
     .form-group.form-inline
       = f.label :closes_at
       -if f.object.cfp_closes.present?
         %span.label.label-info= f.object.cfp_closes
         %br/
       = f.text_field :closes_at, class: 'form-control', value: (f.object.closes_at.blank? ? "" : f.object.closes_at.to_s(:long_with_zone) )
-      -#%p.help-block Open proposal end date is optional. If you do not provide one the CFP will defer to its state.
+      %p.help-block When the CFP will stop taking submissions. Must be set before opening the CFP.
     %h3 Event Dates
     .form-group.form-inline
       = f.label :start_date
       = f.object.start_date.to_s(:month_day_year) unless f.object.start_date.blank?
       = f.text_field :start_date, class: 'form-control', value: (f.object.start_date.blank? ? "" : f.object.start_date.to_s(:month_day_year) )
+      %p.help-block First day of your event
     .form-group.form-inline
       = f.label :end_date
       = f.object.end_date.to_s(:month_day_year) unless f.object.end_date.blank?
       = f.text_field :end_date, class: 'form-control', value: (f.object.end_date.blank? ? "" : f.object.end_date.to_s(:month_day_year) )
-      -#%p.help-block Open proposal end date is optional. If you do not provide one the CFP will defer to its state.
-    .form-group
-      = f.label :state
-      = f.select :state, ['open', 'closed'], class: 'form-control'
+      %p.help-block Last day of your event
 
 .row.col-md-12.form-submit
   - if event && event.persisted? && current_user.admin?

--- a/app/views/admin/events/new.html.haml
+++ b/app/views/admin/events/new.html.haml
@@ -1,9 +1,10 @@
 .row
   .col-md-12
     .page-header
-      %h1 Create a new event
+      %h1 Create a New Event
 
 .row
   .col-md-12
-    = form_for event, url: admin_events_path, html: {role: 'form'} do |f|
+    %span.required_notification * Required
+    = simple_form_for event, url: admin_events_path, html: {role: 'form'} do |f|
       = render partial: 'form', locals: {f: f}

--- a/app/views/organizer/events/edit.html.haml
+++ b/app/views/organizer/events/edit.html.haml
@@ -9,5 +9,6 @@
 
 .row
   .col-md-12
-    = form_for event, url: organizer_event_path(event), html: {role: 'form'} do |f|
+    %span.required_notification * Required
+    = simple_form_for event, url: organizer_event_path(event), html: {role: 'form'} do |f|
       = render partial: @partial, locals: {f: f}

--- a/db/migrate/20160623152512_change_state_column_default_in_events.rb
+++ b/db/migrate/20160623152512_change_state_column_default_in_events.rb
@@ -1,0 +1,5 @@
+class ChangeStateColumnDefaultInEvents < ActiveRecord::Migration
+  def change
+    change_column_default :events, :state, 'draft'
+  end
+end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -7,6 +7,7 @@ describe Event do
         create_list(:event, 3, closes_at: 3.weeks.from_now, state: 'open')
 
       create(:event, closes_at: DateTime.yesterday)
+      create(:event)
       expect(Event.live).to match_array(live_events)
     end
 
@@ -27,6 +28,14 @@ describe Event do
 
     it "returns false for closed events" do
       event = create(:event, state: 'open', closes_at: DateTime.yesterday)
+      expect(event).to_not be_open
+
+      event = create(:event, state: nil, closes_at: 3.weeks.from_now)
+      expect(event).to_not be_open
+    end
+
+    it "returns false for draft events" do
+      event = create(:event)
       expect(event).to_not be_open
 
       event = create(:event, state: nil, closes_at: 3.weeks.from_now)


### PR DESCRIPTION
This PR adds the default state of "draft" to new events. Draft events act like closed events. Also improved usability of event form by changing to simple_form, adding hints and error messages. 
