### PR TITLE
#70 Speaker's My Proposals page

### DIFF
--- a/app/assets/stylesheets/base/_base.scss
+++ b/app/assets/stylesheets/base/_base.scss
@@ -50,3 +50,7 @@ h3.tags {
   z-index: 10000 !important;
 }
 
+.guidelines-link {
+  font-style: italic;
+  margin-left: 5px;
+}

--- a/app/assets/stylesheets/modules/_proposal.scss
+++ b/app/assets/stylesheets/modules/_proposal.scss
@@ -4,7 +4,6 @@
   }
   .btn{
     display: block;
-    width: 150px;
     margin-top: 1em;
   }
 }
@@ -122,6 +121,10 @@ div.col-md-4 {
     h3 {
       display: inline-block;
     }
+}
+
+.invite-btns {
+  margin-top: 10px;
 }
 
 .new-speaker-invite {

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -41,7 +41,7 @@ class InvitationsController < ApplicationController
   def update
     if params[:refuse]
       @invitation.refuse
-      flash[:info] = "You have refused this invitation."
+      flash[:info] = "You have declined this invitation."
       redirect_to root_url
     else
       @invitation.accept

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -2,7 +2,7 @@ class ProposalsController < ApplicationController
   before_filter :require_event, except: :index
   before_filter :require_user
   before_filter :require_proposal, except: [ :index, :create, :new, :parse_edit_field ]
-  before_filter :require_invite, only: [:show]
+  before_filter :require_invite_or_speaker, only: [:show]
   before_filter :require_speaker, only: [:edit, :update]
   before_filter :require_waitlisted_or_accepted_state, only: [:confirm]
 
@@ -99,8 +99,8 @@ class ProposalsController < ApplicationController
                                      speakers_attributes: [:bio, :user_id, :id])
   end
 
-  def require_invite
-    unless current_user.invitations.where(state: 'pending').includes(proposal_id: @proposal.id)
+  def require_invite_or_speaker
+    if !current_user.proposals.where(id: @proposal.id).first && !current_user.invitations.where(state: ['pending', 'accepted'], proposal_id: @proposal.id).first
       redirect_to root_path
       flash[:danger] = 'You are not an invited speaker for the proposal you are trying to access.'
     end
@@ -109,7 +109,7 @@ class ProposalsController < ApplicationController
   def require_speaker
     unless current_user.proposal_ids.include?(@proposal.id)
       redirect_to root_path
-      flash[:danger] = 'You are not a listed speaker on the proposal you are trying to access.'
+      flash[:danger] = 'You are not a listed speaker for the proposal you are trying to access.'
     end
   end
 

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -2,7 +2,8 @@ class ProposalsController < ApplicationController
   before_filter :require_event, except: :index
   before_filter :require_user
   before_filter :require_proposal, except: [ :index, :create, :new, :parse_edit_field ]
-  before_filter :require_speaker, only: [:show, :edit, :update]
+  before_filter :require_invite, only: [:show]
+  before_filter :require_speaker, only: [:edit, :update]
   before_filter :require_waitlisted_or_accepted_state, only: [:confirm]
 
   decorates_assigned :proposal
@@ -96,6 +97,13 @@ class ProposalsController < ApplicationController
     params.require(:proposal).permit(:title, {tags: []}, :session_type_id, :track_id, :abstract, :details, :pitch, custom_fields: @event.custom_fields,
                                      comments_attributes: [:body, :proposal_id, :user_id],
                                      speakers_attributes: [:bio, :user_id, :id])
+  end
+
+  def require_invite
+    unless current_user.invitations.where(state: 'pending').includes(proposal_id: @proposal.id)
+      redirect_to root_path
+      flash[:danger] = 'You are not an invited speaker for the proposal you are trying to access.'
+    end
   end
 
   def require_speaker

--- a/app/decorators/invitation_decorator.rb
+++ b/app/decorators/invitation_decorator.rb
@@ -11,7 +11,7 @@ class InvitationDecorator < ApplicationDecorator
     classes = 'btn btn-danger'
     classes += ' btn-xs' if small
 
-    h.link_to 'Refuse',
+    h.link_to 'Decline',
       h.refuse_invitation_path(invitation_slug: object.slug),
       method: :post,
       class: classes,

--- a/app/decorators/invitation_decorator.rb
+++ b/app/decorators/invitation_decorator.rb
@@ -15,7 +15,7 @@ class InvitationDecorator < ApplicationDecorator
       h.refuse_invitation_path(invitation_slug: object.slug),
       method: :post,
       class: classes,
-      data: { confirm: 'Are you sure you want to refuse this invitation?' }
+      data: { confirm: 'Are you sure you want to decline this invitation?' }
   end
 
   def accept_button(small: false)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 require 'digest/md5'
 
 class User < ActiveRecord::Base
+  STAFF_ROLES = ['reviewer', 'program team', 'organizer']
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable
   devise :database_authenticatable, :registerable,
@@ -9,7 +10,7 @@ class User < ActiveRecord::Base
 
   has_many :invitations,  dependent: :destroy
   has_many :event_teammates, dependent: :destroy
-  has_many :reviewer_event_teammates, -> { where(role: ['reviewer', 'organizer']) }, class_name: 'EventTeammate'
+  has_many :reviewer_event_teammates, -> { where(role: ['reviewer', 'program_team', 'organizer']) }, class_name: 'EventTeammate'
   has_many :reviewer_events, through: :reviewer_event_teammates, source: :event
   has_many :organizer_event_teammates, -> { where(role: 'organizer') }, class_name: 'EventTeammate'
   has_many :organizer_events, through: :organizer_event_teammates, source: :event

--- a/app/views/admin/event_teammate/index.html.haml
+++ b/app/views/admin/event_teammate/index.html.haml
@@ -21,7 +21,7 @@
         = text_field_tag :email, '', class: 'form-control', placeholder: "EventTeammate's email"
       .form-group
         = f.label :role
-        = f.select :role, ['reviewer', 'organizer'], class: 'form-control'
+        = f.select :role, ['reviewer', 'program team', 'organizer'], class: 'form-control'
       .form-submit
         %button.pull-right.btn.btn-primary{:type => "submit"} Save
 - content_for :custom_css do

--- a/app/views/admin/event_teammate/index.html.haml
+++ b/app/views/admin/event_teammate/index.html.haml
@@ -21,7 +21,7 @@
         = text_field_tag :email, '', class: 'form-control', placeholder: "EventTeammate's email"
       .form-group
         = f.label :role
-        = f.select :role, ['reviewer', 'program team', 'organizer'], class: 'form-control'
+        = f.select :role, User::STAFF_ROLES, class: 'form-control'
       .form-submit
         %button.pull-right.btn.btn-primary{:type => "submit"} Save
 - content_for :custom_css do

--- a/app/views/organizer/event_teammate_invitations/_new_dialog.html.haml
+++ b/app/views/organizer/event_teammate_invitations/_new_dialog.html.haml
@@ -7,7 +7,7 @@
         .modal-body
           = f.error_notification
           = f.input :email, class: "form-control"
-          = f.input :role, as: :select, collection: [ 'reviewer', 'program team', 'organizer' ], class: "form-control"
+          = f.input :role, as: :select, collection: User::STAFF_ROLES, class: 'form-control'
 
         .modal-footer
           %button.btn.btn-default{'data-dismiss' => "modal"} Cancel

--- a/app/views/organizer/events/_event_teammate_controls.html.haml
+++ b/app/views/organizer/events/_event_teammate_controls.html.haml
@@ -8,7 +8,7 @@
           %h3 Change event teammate role
         .modal-body
           = f.label :role
-          = f.select :role, ['reviewer', 'program team', 'organizer'], class: 'form-control'
+          = f.select :role, User::STAFF_ROLES, class: 'form-control'
         .modal-footer
           %button.btn.btn-default{'data-dismiss' => "modal"} Cancel
           %button.pull-right.btn.btn-primary{:type => "submit"} Save

--- a/app/views/organizer/events/_event_teammates.html.haml
+++ b/app/views/organizer/events/_event_teammates.html.haml
@@ -3,8 +3,8 @@
     .col-md-12
       .btn-nav.pull-right
         = link_to 'View speakers', organizer_event_speakers_path(event), class: "btn btn-primary"
-        = link_to 'Add/Invite New Event Teammate', '#', class: 'btn btn-primary', data: { toggle: 'modal', target: "#new-event_teammate-event-#{event.id}" }
-        = link_to 'Manage Event Teammate Invitations',
+        = link_to 'Add/Invite New Teammate', '#', class: 'btn btn-primary', data: { toggle: 'modal', target: "#new-event_teammate-event-#{event.id}" }
+        = link_to 'Manage Teammate Invitations',
           organizer_event_event_teammate_invitations_path(event), class: 'btn btn-primary'
       %h3 Event Teammates
 .row

--- a/app/views/organizer/events/_event_teammates.html.haml
+++ b/app/views/organizer/events/_event_teammates.html.haml
@@ -48,7 +48,7 @@
               data: { path: emails_organizer_event_event_teammates_path(event) }
           .form-group
             = f.label :role
-            = f.select :role, ['reviewer', 'program team', 'organizer'], class: 'form-control'
+            = f.select :role, User::STAFF_ROLES, class: 'form-control'
         .modal-footer
           %button.btn.btn-default{'data-dismiss' => "modal"} Cancel
           %button.pull-right.btn.btn-success{:type => "submit"} Save

--- a/app/views/organizer/events/_event_teammates.html.haml
+++ b/app/views/organizer/events/_event_teammates.html.haml
@@ -52,4 +52,3 @@
         .modal-footer
           %button.btn.btn-default{'data-dismiss' => "modal"} Cancel
           %button.pull-right.btn.btn-success{:type => "submit"} Save
-

--- a/app/views/organizer/events/_event_teammates.html.haml
+++ b/app/views/organizer/events/_event_teammates.html.haml
@@ -2,10 +2,10 @@
   %header
     .col-md-12
       .btn-nav.pull-right
-        = link_to 'View speakers', organizer_event_speakers_path(event), class: "btn btn-primary"
+        = link_to 'View speakers', event_staff_speakers_path(event), class: "btn btn-primary"
         = link_to 'Add/Invite New Teammate', '#', class: 'btn btn-primary', data: { toggle: 'modal', target: "#new-event_teammate-event-#{event.id}" }
         = link_to 'Manage Teammate Invitations',
-          organizer_event_event_teammate_invitations_path(event), class: 'btn btn-primary'
+          event_staff_event_teammate_invitations_path(event), class: 'btn btn-primary'
       %h3 Event Teammates
 .row
   .col-md-12
@@ -28,15 +28,15 @@
             %td.notifications
               = event_teammate.comment_notifications
               - if event_teammate.user == current_user
-                = render partial: 'organizer/events/event_teammate_notifications', locals: {event_teammate: event_teammate}
+                = render partial: 'staff/events/event_teammate_notifications', locals: {event_teammate: event_teammate}
             %td.actions
               - unless event_teammate.user == current_user
-                = render partial: 'organizer/events/event_teammate_controls', locals: { event_teammate: event_teammate }
+                = render partial: 'staff/events/event_teammate_controls', locals: { event_teammate: event_teammate }
 
 %div{ id: "new-event_teammate-event-#{event.id}", class: 'modal fade' }
   .modal-dialog
     .modal-content
-      = form_for event.event_teammates.build, url: organizer_event_event_teammates_path(event), html: {role: 'form'} do |f|
+      = form_for event.event_teammates.build, url: event_staff_event_teammates_path(event), html: {role: 'form'} do |f|
         .modal-header
           %h3 Add/Invite an event teammate to #{event.name}
         .modal-body
@@ -45,7 +45,7 @@
             = text_field_tag :email, '', class: 'form-control',
               id: 'autocomplete-email',
               placeholder: "Event Teammate's email",
-              data: { path: emails_organizer_event_event_teammates_path(event) }
+              data: { path: emails_event_staff_event_teammates_path(event) }
           .form-group
             = f.label :role
             = f.select :role, User::STAFF_ROLES, class: 'form-control'

--- a/app/views/proposals/_form.html.haml
+++ b/app/views/proposals/_form.html.haml
@@ -48,4 +48,4 @@
       = render partial: 'preview', locals: { proposal: proposal }
 
       .form-submit.clearfix
-        %button.pull-right.btn.btn-primary.btn-lg{:type => "submit"} Submit Proposal
+        %button.pull-right.btn.btn-primary.btn-lg{:type => "submit"} Save

--- a/app/views/proposals/index.html.haml
+++ b/app/views/proposals/index.html.haml
@@ -24,7 +24,7 @@
 
         .col-md-5.margin-top
           - if event.open?
-            %p.pull-right= link_to 'Submit a proposal', new_proposal_path(slug: event.slug), class: 'btn btn-primary btn-md'
+            %p.pull-right= link_to 'Submit a proposal', new_event_proposal_path(event_slug: event.slug), class: 'btn btn-primary btn-md'
 
             - if event.closes_at?
               %p.pull-right
@@ -55,10 +55,10 @@
                       .toolbox.pull-right
                         .clearfix
                           - unless proposal.withdrawn? || proposal.accepted? || proposal.confirmed?
-                            = link_to edit_proposal_path(slug: event.slug, uuid: proposal), class: 'btn btn-primary' do
+                            = link_to edit_event_proposal_path(event_slug: event.slug, uuid: proposal), class: 'btn btn-primary' do
                               %span.glyphicon.glyphicon-edit
                               Edit
-                    %h4= link_to proposal.title, proposal_path(slug: proposal.event.slug, uuid: proposal)
+                    %h4= link_to proposal.title, event_proposal_path(event_slug: proposal.event.slug, uuid: proposal)
                     = proposal.public_state(small: true)
                     %p
                       %i= truncate(proposal.abstract, length: 80, escape: false)
@@ -90,7 +90,7 @@
             %h5 You don't have any invitations.
           - invitations.each do |invitation|
             %li.invitation
-              %h4.inline-block= link_to invitation.proposal.title, proposal_path(slug: invitation.proposal.event.slug, uuid: invitation.proposal)
+              %h4.inline-block= link_to invitation.proposal.title, event_proposal_path(event_slug: invitation.proposal.event.slug, uuid: invitation.proposal)
               - if invitation.pending?
                 .pull-right.invite-btns
                   = invitation.refuse_button(small: true)

--- a/app/views/proposals/index.html.haml
+++ b/app/views/proposals/index.html.haml
@@ -24,7 +24,6 @@
 
         .col-md-5.margin-top
           - if event.open?
-
             %p.pull-right= link_to 'Submit a proposal', new_proposal_path(slug: event.slug), class: 'btn btn-primary btn-md'
 
             - if event.closes_at?
@@ -67,8 +66,9 @@
                       %strong Session:
                       #{proposal.session_type.name}
                     %p
-                      %strong Track:
-                      #{proposal.track.name}
+                      - if proposal.track
+                        %strong Track:
+                        #{proposal.track.name}
                     %p
                       %strong #{ 'Speaker'.pluralize(proposal.speakers.count) }:
                       = proposal.speakers.collect { |speaker| speaker.name }.join(', ')
@@ -80,15 +80,28 @@
                       = proposal.ratings.count
 
   .col-md-4.invitations
-    %h2 Invitations
-    %ul.list-unstyled
-      - invitations.each do |invitation|
-        %li
-          = invitation.state_label
-          = invitation.proposal.title
-          - if invitation.pending?
-            (
-            = invitation.refuse_button(small: true)
-            |
-            = invitation.accept_button(small: true)
-            )
+    .widget
+      .widget-header
+        %i.fa.fa-envelope-o
+        %h3 Speaker Invitations
+      .widget-content
+        %ul.list-unstyled
+          - if invitations.empty?
+            %h5 You don't have any invitations.
+          - invitations.each do |invitation|
+            %li.invitation
+              %h4.inline-block= link_to invitation.proposal.title, proposal_path(slug: invitation.proposal.event.slug, uuid: invitation.proposal)
+              - if invitation.pending?
+                .pull-right.invite-btns
+                  = invitation.refuse_button(small: true)
+
+                  = invitation.accept_button(small: true)
+              .margin-bottom= invitation.state_label
+              %p
+                - if invitation.proposal.track
+                  %strong Track:
+                  = invitation.proposal.track.name
+              %p
+                %strong #{ 'Speaker'.pluralize(invitation.proposal.speakers.count) }:
+                = invitation.proposal.speakers.collect { |speaker| speaker.name }.join(', ')
+              %hr/

--- a/app/views/proposals/index.html.haml
+++ b/app/views/proposals/index.html.haml
@@ -1,18 +1,22 @@
 .row
   .col-sm-12
     .page-header
-      %h1 Your Dashboard
+      %h1 My Proposals
 .row
   .col-md-8.proposals
-    %h2 Proposals
     - if proposals.empty?
       %h3 You don't have any proposals.
     - proposals.each do |event, talks|
       - if event.open?
-        = link_to 'Submit a proposal', new_event_proposal_path(event_slug: event.slug), class: 'btn btn-primary pull-right'
-      %h3.margin-bottom
-        = link_to event.name, event_path(event.slug), class: 'event-title'
-        %span.label.label-info= event.status
+        = link_to 'Submit a proposal', new_proposal_path(slug: event.slug), class: 'btn btn-primary pull-right'
+      %h2
+        - if event.url?
+          = link_to event.name, event.url, class: 'event-title'
+        - else
+          = link_to event.name, event_path(event.slug), class: 'event-title'
+      %span= link_to 'View Guidelines', event_path(event.slug)
+      %h4.margin-bottom
+        = event.start_date.strftime("%a %b %d") + " - " + event.end_date.strftime("%a %b %d")
       .widget
         .widget-header
           %i.fa.fa-comment

--- a/app/views/proposals/index.html.haml
+++ b/app/views/proposals/index.html.haml
@@ -7,31 +7,47 @@
     - if proposals.empty?
       %h3 You don't have any proposals.
     - proposals.each do |event, talks|
-      - if event.open?
-        = link_to 'Submit a proposal', new_proposal_path(slug: event.slug), class: 'btn btn-primary pull-right'
-        %span.label.label-default.pull-right
-          = pluralize(event.proposals.count, 'proposal')
-          submitted
-      %h2.display.inline-block
-        - if event.url?
-          = link_to event.name, event.url, class: 'event-title'
-        - else
-          = link_to event.name, event_path(event.slug), class: 'event-title'
-      %span= link_to 'View Guidelines', event_path(event.slug), class: 'guidelines-link'
-      %h4.margin-bottom
-        = event.start_date.strftime("%a %b %d") + " - " + event.end_date.strftime("%a %b %d")
-      .widget
-        .widget-header
-          %i.fa.fa-comment
-          %h3 Proposed Talks
-        .widget-content
-          %ul.list-unstyled
-            - talks.each do |proposal|
-              %li.proposal
-                %h4= link_to proposal.title, event_proposal_path(event_slug: proposal.event.slug, uuid: proposal)
-                = proposal.public_state(small: true)
-                %p= truncate(proposal.abstract, length: 80)
-                %hr/
+      - event = event.decorate
+      .row
+        .col-md-7
+          %h2.inline-block
+            - if event.url?
+              = link_to event.name, event.url, class: 'event-title'
+            - else
+              = link_to event.name, event_path(event.slug), class: 'event-title'
+          %span= link_to 'View Guidelines', event_path(event.slug), class: 'guidelines-link'
+          %h4.margin-bottom
+            = event.start_date.strftime("%a %b %d") + " - " + event.end_date.strftime("%a %b %d")
+        .col-md-5
+          - if event.open?
+            = link_to 'Submit a proposal', new_proposal_path(slug: event.slug), class: 'btn btn-primary'
+            %span.label.label-default
+              = pluralize(event.proposals.count, 'proposal')
+              submitted
+            - if event.closes_at?
+              %p
+                Closes at
+                %strong= event.closes_at(:long_with_zone)
+              %p
+                %strong
+                  %span.label.label-info
+                    = time_ago_in_words(event.closes_at)
+                    left
+                &nbsp;to submit your proposal!
+      .row
+        .col-md-12
+          .widget
+            .widget-header
+              %i.fa.fa-comment
+              %h3 Proposed Talks
+            .widget-content
+              %ul.list-unstyled
+                - talks.each do |proposal|
+                  %li.proposal
+                    %h4= link_to proposal.title, proposal_path(slug: proposal.event.slug, uuid: proposal)
+                    = proposal.public_state(small: true)
+                    %p= truncate(proposal.abstract, length: 80)
+                    %hr/
 
   .col-md-4.invitations
     %h2 Invitations

--- a/app/views/proposals/index.html.haml
+++ b/app/views/proposals/index.html.haml
@@ -9,12 +9,15 @@
     - proposals.each do |event, talks|
       - if event.open?
         = link_to 'Submit a proposal', new_proposal_path(slug: event.slug), class: 'btn btn-primary pull-right'
-      %h2
+        %span.label.label-default.pull-right
+          = pluralize(event.proposals.count, 'proposal')
+          submitted
+      %h2.display.inline-block
         - if event.url?
           = link_to event.name, event.url, class: 'event-title'
         - else
           = link_to event.name, event_path(event.slug), class: 'event-title'
-      %span= link_to 'View Guidelines', event_path(event.slug)
+      %span= link_to 'View Guidelines', event_path(event.slug), class: 'guidelines-link'
       %h4.margin-bottom
         = event.start_date.strftime("%a %b %d") + " - " + event.end_date.strftime("%a %b %d")
       .widget

--- a/app/views/proposals/index.html.haml
+++ b/app/views/proposals/index.html.haml
@@ -1,5 +1,5 @@
 .row
-  .col-sm-12
+  .col-md-12
     .page-header
       %h1 My Proposals
 .row
@@ -8,32 +8,40 @@
       %h3 You don't have any proposals.
     - proposals.each do |event, talks|
       - event = event.decorate
+
       .row
         .col-md-7
-          %h2.inline-block
+          %h1.inline-block
             - if event.url?
               = link_to event.name, event.url, class: 'event-title'
             - else
               = link_to event.name, event_path(event.slug), class: 'event-title'
+
           %span= link_to 'View Guidelines', event_path(event.slug), class: 'guidelines-link'
+
           %h4.margin-bottom
             = event.start_date.strftime("%a %b %d") + " - " + event.end_date.strftime("%a %b %d")
-        .col-md-5
+
+        .col-md-5.margin-top
           - if event.open?
-            = link_to 'Submit a proposal', new_proposal_path(slug: event.slug), class: 'btn btn-primary'
-            %span.label.label-default
-              = pluralize(event.proposals.count, 'proposal')
-              submitted
+
+            %p.pull-right= link_to 'Submit a proposal', new_proposal_path(slug: event.slug), class: 'btn btn-primary btn-md'
+
             - if event.closes_at?
-              %p
+              %p.pull-right
                 Closes at
                 %strong= event.closes_at(:long_with_zone)
-              %p
+              %p.pull-right
                 %strong
                   %span.label.label-info
                     = time_ago_in_words(event.closes_at)
                     left
                 &nbsp;to submit your proposal!
+
+            %span.label.label-default.pull-right
+              = pluralize(event.proposals.count, 'proposal')
+              submitted
+
       .row
         .col-md-12
           .widget
@@ -44,10 +52,32 @@
               %ul.list-unstyled
                 - talks.each do |proposal|
                   %li.proposal
+                    - if proposal.has_speaker?(current_user)
+                      .toolbox.pull-right
+                        .clearfix
+                          - unless proposal.withdrawn? || proposal.accepted? || proposal.confirmed?
+                            = link_to edit_proposal_path(slug: event.slug, uuid: proposal), class: 'btn btn-primary' do
+                              %span.glyphicon.glyphicon-edit
+                              Edit
                     %h4= link_to proposal.title, proposal_path(slug: proposal.event.slug, uuid: proposal)
                     = proposal.public_state(small: true)
-                    %p= truncate(proposal.abstract, length: 80)
-                    %hr/
+                    %p
+                      %i= truncate(proposal.abstract, length: 80, escape: false)
+                    %p
+                      %strong Session:
+                      #{proposal.session_type.name}
+                    %p
+                      %strong Track:
+                      #{proposal.track.name}
+                    %p
+                      %strong #{ 'Speaker'.pluralize(proposal.speakers.count) }:
+                      = proposal.speakers.collect { |speaker| speaker.name }.join(', ')
+                    %p
+                      %strong Comments:
+                      = proposal.public_comments.count
+                    %p
+                      %strong Reviews:
+                      = proposal.ratings.count
 
   .col-md-4.invitations
     %h2 Invitations

--- a/app/views/proposals/show.html.haml
+++ b/app/views/proposals/show.html.haml
@@ -18,7 +18,7 @@
           .toolbox.pull-right
             .clearfix
               - unless proposal.withdrawn? || proposal.accepted? || proposal.confirmed?
-                = link_to edit_event_proposal_path(slug: event.slug, uuid: proposal), class: 'btn btn-primary' do
+                = link_to edit_event_proposal_path(event_slug: event.slug, uuid: proposal), class: 'btn btn-primary' do
                   %span.glyphicon.glyphicon-edit
                   Edit
                 -if proposal.has_reviewer_activity?

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160623152512) do
+ActiveRecord::Schema.define(version: 20160622190924) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/features/invitation_spec.rb
+++ b/spec/features/invitation_spec.rb
@@ -110,7 +110,7 @@ feature 'Speaker Invitations' do
     end
 
     context "When declining" do
-      before { click_link 'Refuse' }
+      before { click_link 'Decline' }
 
       it "redirects the user back to the proposal page" do
         expect(page).to have_text("You have refused this invitation")
@@ -119,6 +119,20 @@ feature 'Speaker Invitations' do
       it "marks the invitation as refused" do
         expect(invitation.reload.state).to eq(Invitation::State::REFUSED)
       end
+    end
+
+    it "User can view proposal before accepting invite" do
+      visit proposals_path
+
+      within(:css, 'div.invitations') do
+        expect(page).to have_text(other_proposal.title)
+        expect(page).to have_link("Accept")
+        expect(page).to have_link("Decline")
+      end
+
+      click_link(other_proposal.title)
+
+      expect(current_path).to eq(proposal_path(slug: other_proposal.event.slug, uuid: other_proposal))
     end
   end
 end

--- a/spec/features/invitation_spec.rb
+++ b/spec/features/invitation_spec.rb
@@ -113,7 +113,7 @@ feature 'Speaker Invitations' do
       before { click_link 'Decline' }
 
       it "redirects the user back to the proposal page" do
-        expect(page).to have_text("You have refused this invitation")
+        expect(page).to have_text("You have declined this invitation")
       end
 
       it "marks the invitation as refused" do

--- a/spec/features/invitation_spec.rb
+++ b/spec/features/invitation_spec.rb
@@ -132,7 +132,7 @@ feature 'Speaker Invitations' do
 
       click_link(other_proposal.title)
 
-      expect(current_path).to eq(proposal_path(slug: other_proposal.event.slug, uuid: other_proposal))
+      expect(current_path).to eq(event_proposal_path(event_slug: other_proposal.event.slug, uuid: other_proposal))
     end
   end
 end

--- a/spec/features/proposal_spec.rb
+++ b/spec/features/proposal_spec.rb
@@ -13,7 +13,7 @@ feature "Proposals" do
     fill_in 'Pitch', with: "You live but once; you might as well be amusing. - Coco Chanel"
     fill_in 'Details', with: "Plans are nothing; planning is everything. - Dwight D. Eisenhower"
     select 'Only type', from: 'Session type'
-    click_button 'Submit Proposal'
+    click_button 'Save'
   end
 
   before { login_as(user) }
@@ -61,7 +61,7 @@ feature "Proposals" do
 
       visit edit_event_proposal_path(event_slug: proposal.event.slug, uuid: proposal)
       fill_in 'Title', with: "A new title"
-      click_button 'Submit Proposal'
+      click_button 'Save'
       expect(page).to have_text("A new title")
     end
   end

--- a/spec/features/staff/event_teammates_spec.rb
+++ b/spec/features/staff/event_teammates_spec.rb
@@ -13,7 +13,7 @@ feature "Organizers can manage event_teammates" do
       create(:user, email: 'viktorkrum@durmstrang.edu')
       visit event_staff_path(event)
 
-      click_link 'Add/Invite New Event Teammate'
+      click_link 'Add/Invite New Teammate'
       fill_in 'email', with: 'h'
 
       expect(page).to have_text('harrypotter@hogwarts.edu')

--- a/spec/features/staff/event_teammates_spec.rb
+++ b/spec/features/staff/event_teammates_spec.rb
@@ -13,7 +13,7 @@ feature "Organizers can manage event_teammates" do
       create(:user, email: 'viktorkrum@durmstrang.edu')
       visit event_staff_path(event)
 
-      click_link 'Add/Invite New Teammate'
+      click_link 'Add/Invite New Event Teammate'
       fill_in 'email', with: 'h'
 
       expect(page).to have_text('harrypotter@hogwarts.edu')


### PR DESCRIPTION
This PR restructures and restyles a users 'My Proposals' page, adding additional information regarding the event, the users submitted proposals, and the users invitations to speak. The user can now see the event dates, when the CFP closes, how many invites have been submitted, as well as the track, session, and speaker info, and review and comment count for each submitted proposal. Adds similar info and functionality for invitations. 

Notable additions include: the dates of the conference under it's title, functionality for the event title to link to it's website if it has one or the internal guidelines page if it does not, and invitation titles that link to the proposal show page when the invitation is still pending. 
