### PR TITLE
Created subnav for staff event management pages

### DIFF
--- a/app/assets/stylesheets/base/_base.scss
+++ b/app/assets/stylesheets/base/_base.scss
@@ -2,12 +2,6 @@
   margin-top: 20px;
 }
 
-.alert-viewer-mode {
-  padding: 10px 0;
-  margin-bottom: 20px;
-  background-color: lighten(#E69400, 25%);
-  text-align: center;
-}
 .share {
   font-size: 12px;
 }

--- a/app/controllers/staff/application_controller.rb
+++ b/app/controllers/staff/application_controller.rb
@@ -14,7 +14,7 @@ class Staff::ApplicationController < ApplicationController
     unless @event
       session[:target] = request.path
       flash[:danger] = "You must be signed in as an organizer to access this page."
-      redirect_to new_user_session_url
+      redirect_to root_path
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -71,10 +71,6 @@ module ApplicationHelper
             id: 'copy-filtered-speaker-emails'
   end
 
-  def on_organizer_page?
-    /\/organizer\// =~ request.path
-  end
-
   def modal(identifier, title = '')
     body = capture { yield }
     render 'shared/modal', identifier: identifier, body: body, title: title

--- a/app/views/layouts/_navbar.html.haml
+++ b/app/views/layouts/_navbar.html.haml
@@ -46,6 +46,10 @@
                 = link_to event_staff_sessions_path(event) do
                   %i.fa.fa-calendar
                   Schedule
+              %li{class: "#{request.path == event_staff_path(event) ? 'active' : ''}"}
+                = link_to event_staff_path(event) do
+                  %i.fa.fa-dashboard
+                  %span Event Dashboard
 
           %li{class: "#{request.path == notifications_path ? 'active' : ''}"}
             = link_to notifications_path do
@@ -81,3 +85,32 @@
               %i.fa.fa-dashboard
               %span Dashboard
 
+- if params[:controller].include?("staff") && user_signed_in?
+  .subnavbar
+    .subnavbar-inner
+      .container-fluid
+        %ul.mainnav
+          %li
+            = link_to event_staff_path do
+              %i.fa.fa-dashboard
+              %span Dashboard
+          %li
+            = link_to event_staff_edit_path do
+              %i.fa.fa-info-circle
+              %span Info
+          %li
+            = link_to event_staff_event_teammate_invitations_path do
+              %i.fa.fa-users
+              %span Team
+          %li
+            = link_to event_staff_edit_path do
+              %i.fa.fa-wrench
+              %span Config
+          %li
+            = link_to event_staff_guidelines_notifications_path do
+              %i.fa.fa-list
+              %span Guidelines
+          %li
+            = link_to event_staff_speaker_email_notifications_path do
+              %i.fa.fa-envelope-o
+              %span Speaker Emails

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -22,12 +22,6 @@
   %body{id: body_id}
     = render partial: "layouts/navbar"
 
-  - if on_organizer_page?
-    .alert-viewer-mode
-      .container-fluid
-        Viewing as:
-        %strong Organizer
-
   #flash= show_flash
 
   .main

--- a/app/views/staff/events/show.html.haml
+++ b/app/views/staff/events/show.html.haml
@@ -1,14 +1,7 @@
 .event
   .row
     .col-md-12
-      .page-header.clearfix
-        .btn-nav.pull-right
-          = link_to "Session Types", event_staff_session_types_path(event), class: "btn btn-default"
-          = link_to "Tracks", event_staff_tracks_path(event), class: "btn btn-default"
-          = link_to "Proposals", event_staff_proposals_path(event), class: "btn btn-default"
-          = link_to "Program", event_staff_program_path(event), class: "btn btn-default"
-          = link_to "Schedule", event_staff_sessions_path(event), class: "btn btn-default"
-          = link_to "Edit Event", event_staff_edit_path(event), class: "btn btn-primary"
+      .page-header
         %h1= event
   .row
     .col-sm-4


### PR DESCRIPTION
- Added top navbar link for event dashboard
- Removed "Viewing as Organizer" bar
- Removed existing link buttons from event dashboard

For now, info and config in the subnav both link to edit. This will change when we add new routes/views in cards 63 and 67.
