### PR TITLE
#71  - Modifies event CFP page layout

### DIFF
--- a/app/assets/stylesheets/modules/_buttons.scss
+++ b/app/assets/stylesheets/modules/_buttons.scss
@@ -9,3 +9,15 @@
     }
   }
 }
+
+/**
+ * Extra large button extensions. Extends `.btn`.
+ */
+.btn-xlarge {
+  padding: 12px 22px;
+  font-size: 22px;
+  line-height: normal;
+  -webkit-border-radius: 8px;
+     -moz-border-radius: 8px;
+          border-radius: 8px;
+}

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -3,8 +3,10 @@
     .page-header
       .share.pull-right= event.tweet_button
       %h1
-        = link_to(event, event_path(event.slug))
-        %span.label.label-primary= event.status
+        - if event.url?
+          = link_to event.name, "http://#{event.url}", target: 'blank', class: 'event-title'
+        - else
+          = event.name
 
 .row.margin-top
   .col-md-8
@@ -17,18 +19,23 @@
   .col-md-4
     - if event.open?
 
-      %p= link_to 'Submit a proposal', new_event_proposal_path, class: 'btn btn-primary btn-lg'
+      .pull-right= link_to 'Submit a proposal', new_event_proposal_path, class: 'btn btn-primary btn-xlarge'
 
       - if event.closes_at?
-        %p
+        %h4.pull-right
           Closes at
           %strong= event.closes_at(:long_with_zone)
-        %p
+        %h4.pull-right
           %strong
             %span.label.label-info
               = time_ago_in_words(event.closes_at)
               left
           &nbsp;to submit your proposal!
+
+        %h4.pull-right
+          %span.label.label-default
+            = pluralize(event.proposals.count, 'proposal')
+            submitted
 
     - if event.proposals.count > 5
       .stats

--- a/app/views/proposals/index.html.haml
+++ b/app/views/proposals/index.html.haml
@@ -13,9 +13,9 @@
         .col-md-7
           %h1.inline-block
             - if event.url?
-              = link_to event.name, event.url, class: 'event-title'
+              = link_to event.name, "http://#{event.url}", target: 'blank', class: 'event-title'
             - else
-              = link_to event.name, event_path(event.slug), class: 'event-title'
+              = event.name
 
           %span= link_to 'View Guidelines', event_path(event.slug), class: 'guidelines-link'
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160622190924) do
+ActiveRecord::Schema.define(version: 20160623152512) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/features/event_spec.rb
+++ b/spec/features/event_spec.rb
@@ -22,4 +22,26 @@ feature "Listing events for different roles" do
       expect(page).to have_link('1 proposal', href: event_staff_proposals_path(event))
     end
   end
+
+  context "Event CFP page" do
+    scenario "the user sees proper stats" do
+      visit event_path(event.slug)
+
+      expect(page).to have_content event.name
+      expect(page).to have_link 'Submit a proposal'
+      expect(page).to have_content "Closes at #{(DateTime.now + 21.days).strftime('%b %-d')}"
+      expect(page).to have_content '21 days left to submit your proposal'
+      expect(page).to have_content '1 proposal submitted'
+    end
+
+    scenario "the event title is a link if it's set" do
+      new_event = Event.create(name: "Coolest Event", slug: "cool", url: "", state: "open")
+      visit event_path(new_event.slug)
+
+      within('.page-header') do
+        expect(page).to have_content "Coolest Event"
+        expect(page).to_not have_link new_event.name
+      end
+    end
+  end
 end


### PR DESCRIPTION
Adds logic so that the event name is a link to outside url if it's set and a static title if not. Enlarges CFP stats on right side of page. 
