### PR TITLE
#68 - Updated event staff dashboard.

### DIFF
--- a/app/assets/stylesheets/modules/_events.css.scss
+++ b/app/assets/stylesheets/modules/_events.css.scss
@@ -1,5 +1,19 @@
 .event {
-
+  .info-bar {
+    h4 {
+      line-height: 1.35em;
+    }
+  }
+  .checklist {
+    .set {
+      color: $white;
+      background-color: $brand-success;
+    }
+    .missing {
+      color: $white;
+      background-color: $brand-danger;
+    }
+  }
 }
 
 

--- a/app/assets/stylesheets/modules/_events.css.scss
+++ b/app/assets/stylesheets/modules/_events.css.scss
@@ -5,13 +5,17 @@
     }
   }
   .checklist {
-    .set {
+    a {
       color: $white;
+    }
+    .set {
       background-color: $brand-success;
     }
     .missing {
-      color: $white;
       background-color: $brand-danger;
+    }
+    .optional a {
+      color: $black;
     }
   }
 }

--- a/app/decorators/event_decorator.rb
+++ b/app/decorators/event_decorator.rb
@@ -57,6 +57,16 @@ class EventDecorator < ApplicationDecorator
     twitter_button("Check out the CFP for #{object}!")
   end
 
+  def date_range
+    if (object.start_date.month == object.end_date.month) && (event.start_date.day != event.end_date.day)
+      object.start_date.strftime("%b %d") + object.end_date.strftime("\-%d, %Y")
+    elsif (object.start_date.month == object.end_date.month) && (event.start_date.day == event.end_date.day)
+      object.start_date.strftime("%b %d, %Y")
+    else
+      object.start_date.strftime("%b %d") + object.end_date.strftime("\-%b %d, %Y")
+    end
+  end
+
   def confirmed_percent
     if proposals.accepted.confirmed.count > 0
       "#{((object.proposals.accepted.confirmed.count.to_f/object.proposals.accepted.count.to_f)*100).round(1)}%"

--- a/app/views/admin/event_teammate/index.html.haml
+++ b/app/views/admin/event_teammate/index.html.haml
@@ -2,7 +2,7 @@
 .row
   .col-md-6
     - if event_teammates.empty?
-      %h2 No event_teammates in this event
+      %h2 No event teammates in this event
     - event_teammates.group_by(&:role).each_pair do |role, role_event_teammates|
       %h2= role.capitalize.pluralize
       - role_event_teammates.each do |event_teammate|
@@ -14,11 +14,11 @@
               %span.glyphicon.glyphicon-trash
               Delete
   %fieldset.col-md-6
-    %h2 Add event_teammate
+    %h2 Add event teammate
     = form_for event_teammate, url: admin_event_event_teammates_path, html: {role: 'form'} do |f|
       .form-group
         = label_tag :email
-        = text_field_tag :email, '', class: 'form-control', placeholder: "EventTeammate's email"
+        = text_field_tag :email, '', class: 'form-control', placeholder: "Event Teammate's email"
       .form-group
         = f.label :role
         = f.select :role, User::STAFF_ROLES, class: 'form-control'

--- a/app/views/staff/event_teammate_invitations/_new_dialog.html.haml
+++ b/app/views/staff/event_teammate_invitations/_new_dialog.html.haml
@@ -7,7 +7,7 @@
         .modal-body
           = f.error_notification
           = f.input :email, class: "form-control"
-          = f.input :role, as: :select, collection: [ 'reviewer', 'program team', 'organizer' ], class: "form-control"
+          = f.input :role, as: :select, collection: User::STAFF_ROLES, class: "form-control"
 
         .modal-footer
           %button.btn.btn-default{'data-dismiss' => "modal"} Cancel

--- a/app/views/staff/event_teammate_invitations/index.html.haml
+++ b/app/views/staff/event_teammate_invitations/index.html.haml
@@ -3,7 +3,7 @@
     .page-header.clearfix
       .btn-nav.pull-right
         = new_event_teammate_invitation_button
-      %h1 Pending &amp; Refused EventTeammate Invitations
+      %h1 Pending &amp; Refused Event Teammate Invitations
 
 .row
   .col-md-12

--- a/app/views/staff/events/_event_teammate_controls.html.haml
+++ b/app/views/staff/events/_event_teammate_controls.html.haml
@@ -5,10 +5,10 @@
     .modal-content
       = form_for event_teammate, url: event_staff_event_teammate_path(event_teammate.event, event_teammate), html: { role: 'form' } do |f|
         .modal-header
-          %h3 Change event_teammate role
+          %h3 Change event teammate role
         .modal-body
           = f.label :role
-          = f.select :role, ['reviewer', 'organizer'], class: 'form-control'
+          = f.select :role, User::STAFF_ROLES, class: 'form-control'
         .modal-footer
           %button.btn.btn-default{'data-dismiss' => "modal"} Cancel
           %button.pull-right.btn.btn-primary{:type => "submit"} Save

--- a/app/views/staff/events/_event_teammates.html.haml
+++ b/app/views/staff/events/_event_teammates.html.haml
@@ -7,7 +7,7 @@
           = link_to 'Add/Invite Staff', '#', class: 'btn btn-primary', data: { toggle: 'modal', target: "#new-event_teammate-event-#{event.id}" }
           = link_to 'Manage Staff Invites',
             event_staff_event_teammate_invitations_path(event), class: 'btn btn-primary'
-      %h3 EventTeammates
+      %h3 Event Teammates
 .row
   .col-md-12
     %table.event_teammates.table.table-striped
@@ -50,7 +50,7 @@
               data: { path: emails_event_staff_event_teammates_path(event) }
           .form-group
             = f.label :role
-            = f.select :role, ['reviewer', 'organizer'], {}, {class: 'form-control'}
+            = f.select :role, User::STAFF_ROLES, {}, {class: 'form-control'}
         .modal-footer
           %button.btn.btn-default{'data-dismiss' => "modal"} Cancel
           %button.pull-right.btn.btn-success{:type => "submit"} Save

--- a/app/views/staff/events/show.html.haml
+++ b/app/views/staff/events/show.html.haml
@@ -1,14 +1,28 @@
 .event
   .row
     .col-md-12
-      .page-header
-        %h1= event
+      .page-header.info-bar
+        %h4.pull-right
+          %strong CFP Status:
+          = event.state
+          %br
+          - if event.closes_at?
+            Closes at
+            %strong= event.closes_at(:long_with_zone)
+        %h1
+          - if event.url?
+            = link_to event.name, "http://#{event.url}", target: 'blank', class: 'event-title'
+          - else
+            = event.name
+        %h4
+          - if event.start_date? && event.end_date?
+            = event.date_range
   .row
     .col-sm-4
       .widget.widget-table
         .widget-header
           %i.fa.fa-calendar
-          %h3 Event Details
+          %h3 Details
         .widget-content
           %table.table.table-striped.table-bordered
             %tbody
@@ -19,30 +33,8 @@
                   %a{ href: event.url }#{event.url}
               %tr
                 %td.text-primary
-                  %strong Slug:
-                %td #{event.slug}
-              %tr
-                %td.text-primary
                   %strong Email:
                 %td #{event.contact_email}
-              %tr
-                %td.text-primary
-                  %strong Guidelines:
-                %td
-                  -if event.guidelines.present?
-                    = event.guidelines.truncate(150, separator: /\s/)
-                  %p= link_to "View Public Guidelines", event_path(slug: event.slug), class: "btn btn-success"
-
-                  - if current_user.can_edit?
-                    %p= link_to "<i class='fa fa-pencil'></i> Edit Guidelines".html_safe, event_staff_guidelines_notifications_path, class: "btn btn-primary"
-
-      .widget.widget-table
-        .widget-header
-          %i.fa.fa-calendar
-          %h3 CFP Details
-        .widget-content
-          %table.table.table-striped.table-bordered
-            %tbody
               %tr
                 %td.text-primary
                   %strong CFP Opens:
@@ -51,137 +43,186 @@
                 %td.text-primary
                   %strong CFP Closes:
                 %td= event.cfp_closes
-
               %tr
                 %td.text-primary
-                  %strong Days Remaining:
-                %td #{event.cfp_days_remaining}
+                  %strong Event Staff:
+                %td= event_teammates.count
+              -# %tr
+                -# %td.text-primary
+                -#   %strong Guidelines:
+                -# %td
+                -#   -if event.guidelines.present?
+                -#     = event.guidelines.truncate(150, separator: /\s/)
+                -#   = link_to "Public guidelines", event_path(slug: event.slug)
+                -#   %p= link_to "<i class='fa fa-pencil'></i> Edit Guidelines".html_safe, event_staff_guidelines_notifications_path, class: "btn btn-primary"
 
-              %tr
-                %td.text-primary
-                  %strong Event Start:
-                %td #{event.start_date.to_s(:month_day_year) unless event.start_date.blank?}
-
-              %tr
-                %td.text-primary
-                  %strong Event End:
-                %td #{event.end_date.to_s(:month_day_year) unless event.end_date.blank?}
+      -# .widget.widget-table
+      -#   .widget-header
+      -#     %i.fa.fa-calendar
+      -#     %h3 CFP Details
+      -#   .widget-content
+      -#     %table.table.table-striped.table-bordered
+      -#       %tbody
+      -#         %tr
+      -#           %td.text-primary
+      -#             %strong Days Remaining:
+      -#           %td #{event.cfp_days_remaining}
+      -#         %tr
+      -#           %td.text-primary
+      -#             %strong Event Start:
+      -#           %td #{event.start_date.to_s(:month_day_year) unless event.start_date.blank?}
+      -#         %tr
+      -#           %td.text-primary
+      -#             %strong Event End:
+      -#           %td #{event.end_date.to_s(:month_day_year) unless event.end_date.blank?}
 
 
     .col-sm-4
       .widget
         .widget-header
           %i.fa.fa-list-alt
-          %h3 Proposal Stats
-        .widget-content
-          .row
-            .col-sm-12
-              %h4
-                %strong.text-primary Total:
-                %span.label.label-info #{event.proposals.count}
-          .row
-            .col-sm-12
-              %h4
-                %strong.text-primary Reviewed:
-                %span.label.label-info #{event.proposals.rated.count} (#{event.reviewed_percent})
-          - if current_user.can_edit?
-            .row
-              .col-sm-12
-                %h4
-                  %strong.text-primary Accepted:
-                  %span.label.label-info #{event.proposals.accepted.count}
-            .row
-              .col-sm-12
-                %h4
-                  %strong.text-primary Confirmed:
-                  %span.label.label-info #{event.proposals.accepted.confirmed.count} (#{event.confirmed_percent})
-            .row
-              .col-sm-12
-                %h4
-                  %strong.text-primary Scheduled:
-                  %span.label.label-info #{event.proposals.scheduled.count} (#{event.scheduled_percent})
-            .row
-              .col-sm-12
-                %h4
-                  %strong.text-primary Waitlisted:
-                  %span.label.label-info #{event.proposals.waitlisted.count}
-            .row
-              .col-sm-12
-                %h4
-                  %strong.text-primary Confirmed:
-                  %span.label.label-info #{event.proposals.waitlisted.confirmed.count} (#{event.waitlisted_percent})
-
-      .widget
-        .widget-header
-          %i.fa.fa-tags
-          %h3 Proposal Tags
-        .widget-content
-          =event.valid_proposal_tags
-
-      .widget
-        .widget-header
-          %i.fa.fa-tags
-          %h3 Review Tags
-          - if current_user.can_edit?
-            = link_to "<i class='fa fa-pencil'></i> Edit".html_safe, event_staff_edit_path, class: "btn btn-sm btn-primary pull-right"
-        .widget-content
-          =event.valid_review_tags
-
-      .widget
-        .widget-header
-          %i.fa.fa-tags
-          %h3 Fields
-          - if current_user.can_edit?
-            = link_to "<i class='fa fa-plus'></i> Add Custom Field".html_safe, event_staff_custom_fields_path(event), class: "btn btn-primary btn-sm pull-right"
-        .widget-content
-          %ul.list-unstyled
-            %li
-              %h5.text-primary
-                %strong Standard
-            %li
-              %p=event.fields
-          %hr/
-          %ul.list-unstyled
-            %li
-              %h5.text-primary
-                %strong Custom Fields
-            %li
-              %p=event.custom_fields.join(", ")
-
-    .col-sm-4
-      .widget
-        .widget-header
-          %i.fa.fa-tags
-          %h3 Tracks
-        .widget-content
-          -if event.track_count.present?
-            - event.track_count.sort_by{|k,v| v}.reverse.each_slice(8).to_a.each do |row|
-              %ul#columns.list-inline
-                -row.each do |name, count|
-                  %li
-                    .label.label-success
-                      = name
-                      = count
-          -else
-            %p No Tracks
-
-      .widget
-        .widget-header
-          %i.fa.fa-tags
-          %h3 Speaker Notifications
-          - if current_user.can_edit?
-            = link_to "<i class='fa fa-pencil'></i> Edit".html_safe, event_staff_speaker_email_notifications_path, class: "btn btn-sm btn-primary pull-right"
+          %h3 CFP Statistics
         .widget-content
           %ul.list-group
             %li.list-group-item
-              %strong.text-primary Accept:
-              %p=event.speaker_notification_emails['accept'].truncate(75, separator: /\s/)
+              %strong.text-primary Total:
+              %span.label.label-info #{event.proposals.count}
             %li.list-group-item
-              %strong.text-primary Reject:
-              %p=event.speaker_notification_emails['reject'].truncate(75, separator: /\s/)
+              %strong.text-primary Total Proposals Reviewed:
+              %span.label.label-info #{event.proposals.rated.count} (#{event.reviewed_percent})
             %li.list-group-item
-              %strong.text-primary Waitlist:
-              %p=event.speaker_notification_emails['waitlist'].truncate(75, separator: /\s/)
+              %strong.text-primary Reviewed Proposals Accepted:
+              %span.label.label-info #{event.proposals.accepted.count}
+            -# %li.list-group-item
+            -#   %strong.text-primary Confirmed:
+            -#   %span.label.label-info #{event.proposals.accepted.confirmed.count} (#{event.confirmed_percent})
+            %li.list-group-item
+              %strong.text-primary Accepted Sessions Scheduled:
+              %span.label.label-info #{event.proposals.scheduled.count} (#{event.scheduled_percent})
+            %li.list-group-item
+              %strong.text-primary Waitlisted Sessions:
+              %span.label.label-info #{event.proposals.waitlisted.count}
+            -# %li.list-group-item
+            -#   %strong.text-primary Confirmed:
+            -#   %span.label.label-info #{event.proposals.waitlisted.confirmed.count} (#{event.waitlisted_percent})
 
-  %hr/
-  = render partial: 'event_teammates', locals: { event: event, event_teammates: event_teammates, rating_counts: rating_counts }
+    .col-sm-4
+      .widget.widget-table.checklist
+        .widget-header
+          %i.fa.fa-check-square-o
+          %h3 Checklist
+        .widget-content
+          %table.table.table-striped.table-bordered
+            %tbody
+              %tr
+                %td.text-primary
+                  %strong Event Url:
+                - if event.url.present?
+                  %td.set Set
+                - else
+                  %td.missing Missing
+              %tr
+                %td.text-primary
+                  %strong Event Dates:
+                - if event.start_date.present? && event.end_date.present?
+                  %td.set Set
+                - else
+                  %td.missing Missing
+              %tr
+                %td.text-primary
+                  %strong Contact Email:
+                - if event.contact_email.present?
+                  %td.set Set
+                - else
+                  %td.missing Missing
+              %tr
+                %td.text-primary
+                  %strong CFP Closes Date:
+                - if event.closes_at.present?
+                  %td.set Set
+                - else
+                  %td.missing Missing
+              %tr
+                %td.text-primary
+                  %strong Session Types:
+                - if event.session_types.present?
+                  %td.set= event.session_types.count
+                - else
+                  %td.missing None
+              %tr
+                %td.text-primary
+                  %strong Tracks:
+                - if event.tracks.present?
+                  %td.set= event.tracks.count
+                - else
+                  %td None (optional)
+              %tr
+                %td.text-primary
+                  %strong Guidelines:
+                - if event.guidelines.present?
+                  %td.set Set
+                - else
+                  %td.missing Missing
+
+    -#
+    -#   .widget
+    -#     .widget-header
+    -#       %i.fa.fa-tags
+    -#       %h3 Proposal Tags
+    -#     .widget-content
+    -#       =event.valid_proposal_tags
+    -#
+    -#   .widget
+    -#     .widget-header
+    -#       %i.fa.fa-tags
+    -#       %h3 Review Tags
+    -#       = link_to "<i class='fa fa-pencil'></i> Edit".html_safe, event_staff_edit_path, class: "btn btn-sm btn-primary pull-right"
+    -#     .widget-content
+    -#       =event.valid_review_tags
+    -#
+    -#   .widget
+    -#     .widget-header
+    -#       %i.fa.fa-tags
+    -#       %h3 Fields
+    -#       = link_to "<i class='fa fa-plus'></i> Add Custom Field".html_safe, event_staff_custom_fields_path(event), class: "btn btn-primary btn-sm pull-right"
+    -#     .widget-content
+    -#       %p=event.fields
+    -#       %h4 Custom Fields
+    -#       %p=event.custom_fields.join(", ")
+    -#
+    -# .col-sm-4
+    -#   .widget
+    -#     .widget-header
+    -#       %i.fa.fa-tags
+    -#       %h3 Tracks
+    -#     .widget-content
+    -#       -if event.track_count.present?
+    -#         - event.track_count.sort_by{|k,v| v}.reverse.each_slice(8).to_a.each do |row|
+    -#           %ul#columns.list-inline
+    -#             -row.each do |name, count|
+    -#               %li
+    -#                 .label.label-success
+    -#                   = name
+    -#                   = count
+    -#       -else
+    -#         %p No Tracks
+    -#
+    -#   .widget
+    -#     .widget-header
+    -#       %i.fa.fa-tags
+    -#       %h3 Speaker Notifications
+    -#       = link_to "<i class='fa fa-pencil'></i> Edit".html_safe, event_staff_speaker_email_notifications_path, class: "btn btn-sm btn-primary pull-right"
+    -#     .widget-content
+    -#       %ul.list-group
+    -#         %li.list-group-item
+    -#           %strong.text-primary Accept:
+    -#           %p=event.speaker_notification_emails['accept'].truncate(75, separator: /\s/)
+    -#         %li.list-group-item
+    -#           %strong.text-primary Reject:
+    -#           %p=event.speaker_notification_emails['reject'].truncate(75, separator: /\s/)
+    -#         %li.list-group-item
+    -#           %strong.text-primary Waitlist:
+    -#           %p=event.speaker_notification_emails['waitlist'].truncate(75, separator: /\s/)
+
+  -# %hr/
+  -# = render partial: 'event_teammates', locals: { event: event, event_teammates: event_teammates, rating_counts: rating_counts }

--- a/app/views/staff/events/show.html.haml
+++ b/app/views/staff/events/show.html.haml
@@ -118,51 +118,51 @@
                 %td.text-primary
                   %strong Event Url:
                 - if event.url.present?
-                  %td.set Set
+                  %td.set= link_to "Set", event_staff_edit_path
                 - else
-                  %td.missing Missing
+                  %td.missing= link_to "Missing", event_staff_edit_path
               %tr
                 %td.text-primary
                   %strong Event Dates:
                 - if event.start_date.present? && event.end_date.present?
-                  %td.set Set
+                  %td.set= link_to "Set", event_staff_edit_path
                 - else
-                  %td.missing Missing
+                  %td.missing= link_to "Missing", event_staff_edit_path
               %tr
                 %td.text-primary
                   %strong Contact Email:
                 - if event.contact_email.present?
-                  %td.set Set
+                  %td.set= link_to "Set", event_staff_edit_path
                 - else
-                  %td.missing Missing
+                  %td.missing= link_to "Missing", event_staff_edit_path
               %tr
                 %td.text-primary
                   %strong CFP Closes Date:
                 - if event.closes_at.present?
-                  %td.set Set
+                  %td.set= link_to "Set", event_staff_edit_path
                 - else
-                  %td.missing Missing
+                  %td.missing= link_to "Missing", event_staff_edit_path
               %tr
                 %td.text-primary
                   %strong Session Types:
                 - if event.session_types.present?
-                  %td.set= event.session_types.count
+                  %td.set= link_to event.session_types.count, '#'
                 - else
-                  %td.missing None
+                  %td.missing= link_to "None", '#'
               %tr
                 %td.text-primary
                   %strong Tracks:
                 - if event.tracks.present?
-                  %td.set= event.tracks.count
+                  %td.set= link_to event.tracks.count, '#'
                 - else
-                  %td None (optional)
+                  %td.optional= link_to "None (optional)", '#'
               %tr
                 %td.text-primary
                   %strong Guidelines:
                 - if event.guidelines.present?
-                  %td.set Set
+                  %td.set= link_to "Set", event_staff_guidelines_notifications_path
                 - else
-                  %td.missing Missing
+                  %td.missing= link_to "Missing", event_staff_guidelines_notifications_path
 
     -#
     -#   .widget

--- a/spec/features/staff/event_spec.rb
+++ b/spec/features/staff/event_spec.rb
@@ -80,6 +80,7 @@ feature "Event Dashboard" do
     end
 
     it "can promote a user" do
+      pending "This fails because add/invite new teammate is no longer on this page. Change path once new card is complete"
       user = create(:user)
       visit event_staff_path(event)
       click_link 'Add/Invite Staff'
@@ -93,6 +94,7 @@ feature "Event Dashboard" do
     end
 
     it "can promote an event teammate" do
+      pending "This fails because the event teammates section is no longer on this page. Change path once new card is complete"
       visit event_staff_path(event)
 
       form = find('tr', text: reviewer_user.email).find('form')
@@ -103,6 +105,7 @@ feature "Event Dashboard" do
     end
 
     it "can remove a event teammate" do
+      pending "This fails because add/invite new teammate is no longer on this page. Change path once new card is complete"
       visit event_staff_path(event)
 
       row = find('tr', text: reviewer_user.email)

--- a/spec/features/staff/event_teammates_spec.rb
+++ b/spec/features/staff/event_teammates_spec.rb
@@ -7,6 +7,7 @@ feature "Staff Organizers can manage event_teammates" do
   before { login_as(organizer) }
 
   context "adding a new event_teammate" do
+    pending "This fails because add/invite new teammate is no longer on this page. Change path once new card is complete"
     it "autocompletes email addresses", js: true do
       create(:user, email: 'harrypotter@hogwarts.edu')
       create(:user, email: 'hermionegranger@hogwarts.edu')


### PR DESCRIPTION
This PR deals with updating the event dashboard. Information that previously lived on the dashboard will move to new pages in upcoming cards. Rather than deleting info, I commented out what will no longer appear on the page since those elements will move to other pages. I didn't know if we wanted to remove it completely yet, or if having it commented would make it easier to move to other pages. I'd love feedback on how everything is laid out, particularly the checklist, once you all look over the pr and read the card. I also fixed instances of EventTeammate and event_teammate that had snuck into the views, and changed all instances of the role dropdown to use the constants.
