### PR TITLE
#61 current event session

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,7 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
-  helper_method :current_user
+  helper_method :current_event
   helper_method :user_signed_in?
   helper_method :reviewer?
   helper_method :organizer?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
+  helper_method :current_user
   helper_method :user_signed_in?
   helper_method :reviewer?
   helper_method :organizer?
@@ -16,6 +17,10 @@ class ApplicationController < ActionController::Base
   end
 
   private
+
+  def current_event
+    @current_event ||= Event.find_by(id: session[:event_id]) if session[:event_id]
+  end
 
   def reviewer?
     @is_reviewer ||= current_user.reviewer?

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -8,5 +8,6 @@ class EventsController < ApplicationController
   end
 
   def show
+    session[:event_id] = event.id
   end
 end

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -28,7 +28,8 @@ class InvitationsController < ApplicationController
   def show
     render locals: {
       proposal: @invitation.proposal.decorate,
-      invitation: @invitation.decorate
+      invitation: @invitation.decorate,
+      event: @invitation.proposal.event.decorate
     }
   end
 

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -62,7 +62,8 @@ class ProposalsController < ApplicationController
     session[:event_id] = event.id
 
     render locals: {
-      invitations: @proposal.invitations.not_accepted.decorate
+      invitations: @proposal.invitations.not_accepted.decorate,
+      event: @proposal.event.decorate
     }
   end
 

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -59,6 +59,8 @@ class ProposalsController < ApplicationController
   end
 
   def show
+    session[:event_id] = event.id
+
     render locals: {
       invitations: @proposal.invitations.not_accepted.decorate
     }

--- a/app/decorators/event_decorator.rb
+++ b/app/decorators/event_decorator.rb
@@ -24,6 +24,14 @@ class EventDecorator < ApplicationDecorator
     h.link_to h.pluralize(object.proposals.count, 'proposal'), path
   end
 
+  def event_path_for
+    if object.url?
+      h.link_to object.name, object.url, target: 'blank', class: 'event-title'
+    else
+      object.name
+    end
+  end
+
   def cfp_days_remaining
     ((object.closes_at - DateTime.now).to_i / 1.day) if object.closes_at && (object.closes_at - DateTime.now).to_i / 1.day > 1
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,9 @@
 module ApplicationHelper
 
+  def current_event
+    @current_event ||= Event.find_by(id: session[:event_id]) if session[:event_id]
+  end
+
   def title
     if @title.blank?
       "CFPApp"

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,9 +1,5 @@
 module ApplicationHelper
 
-  def current_event
-    @current_event ||= Event.find_by(id: session[:event_id]) if session[:event_id]
-  end
-
   def title
     if @title.blank?
       "CFPApp"

--- a/app/views/events/index.html.haml
+++ b/app/views/events/index.html.haml
@@ -1,10 +1,7 @@
 - events.each do |event|
   .event
     %h1
-      - if event.url?
-        = link_to event.name, "#{event.url}", target: 'blank', class: 'event-title'
-      - else
-        = event.name
+      = event.event_path_for
       %small= event.status
 
-    %span= link_to 'View Guidelines', event_path(event.slug), class: 'guidelines-link'
+    %span= link_to "View #{event.name}'s Guidelines", event_path(event.slug), class: 'guidelines-link'

--- a/app/views/events/index.html.haml
+++ b/app/views/events/index.html.haml
@@ -1,7 +1,10 @@
 - events.each do |event|
   .event
     %h1
-      -if current_user
-        = link_to(event, event_path(event.slug))
+      - if event.url?
+        = link_to event.name, "#{event.url}", target: 'blank', class: 'event-title'
+      - else
+        = event.name
       %small= event.status
-    = event.path_for(current_user)
+
+    %span= link_to 'View Guidelines', event_path(event.slug), class: 'guidelines-link'

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -4,7 +4,7 @@
       .share.pull-right= event.tweet_button
       %h1
         - if event.url?
-          = link_to event.name, "http://#{event.url}", target: 'blank', class: 'event-title'
+          = link_to event.name, "#{event.url}", target: 'blank', class: 'event-title'
         - else
           = event.name
 

--- a/app/views/invitations/show.html.haml
+++ b/app/views/invitations/show.html.haml
@@ -7,4 +7,4 @@
     = invitation.refuse_button
     = invitation.accept_button
 
-= render template: 'proposals/show', locals: { proposal: proposal }
+= render template: 'proposals/show', locals: { proposal: proposal, event: event }

--- a/app/views/layouts/_navbar.html.haml
+++ b/app/views/layouts/_navbar.html.haml
@@ -6,7 +6,7 @@
         %span.icon-bar
         %span.icon-bar
       - if current_event && current_event.slug
-        = link_to current_event.name, event_path(slug: current_event.slug), class: 'navbar-brand'
+        = link_to current_event.name, event_path(current_event), class: 'navbar-brand'
       - else
         = link_to "#{Rails.application.class.parent_name}", events_path, class: 'navbar-brand'
 

--- a/app/views/layouts/_navbar.html.haml
+++ b/app/views/layouts/_navbar.html.haml
@@ -5,8 +5,8 @@
         %span.icon-bar
         %span.icon-bar
         %span.icon-bar
-      - if event && event.slug
-        = link_to event.name, event_path(slug: event.slug), class: 'navbar-brand'
+      - if current_event && current_event.slug
+        = link_to current_event.name, event_path(slug: current_event.slug), class: 'navbar-brand'
       - else
         = link_to "#{Rails.application.class.parent_name}", events_path, class: 'navbar-brand'
 

--- a/app/views/proposals/index.html.haml
+++ b/app/views/proposals/index.html.haml
@@ -13,7 +13,7 @@
         .col-md-7
           %h1.inline-block
             - if event.url?
-              = link_to event.name, "http://#{event.url}", target: 'blank', class: 'event-title'
+              = link_to event.name, "#{event.url}", target: 'blank', class: 'event-title'
             - else
               = event.name
 

--- a/app/views/proposals/index.html.haml
+++ b/app/views/proposals/index.html.haml
@@ -20,7 +20,7 @@
           %span= link_to 'View Guidelines', event_path(event.slug), class: 'guidelines-link'
 
           %h4.margin-bottom
-            = event.start_date.strftime("%a %b %d") + " - " + event.end_date.strftime("%a %b %d")
+            = event.date_range
 
         .col-md-5.margin-top
           - if event.open?

--- a/app/views/proposals/show.html.haml
+++ b/app/views/proposals/show.html.haml
@@ -3,8 +3,9 @@
     .row
       .col-md-8
         %h3
-          = link_to(proposal.event.name, event_path(slug: proposal.event.slug) ) + ","
-          %span.label.label-info= proposal.event.start_date.to_s(:month_day_year)
+          = link_to(proposal.event.name, event_path(slug: proposal.event.slug) )
+        %span.text-info= event.start_date.strftime("%a %b %d") + " - " + event.end_date.strftime("%a %b %d")
+
         %h1
           = proposal.title
           %small

--- a/app/views/proposals/show.html.haml
+++ b/app/views/proposals/show.html.haml
@@ -3,8 +3,8 @@
     .row
       .col-md-8
         %h3
-          = link_to(proposal.event.name, event_path(slug: proposal.event.slug) )
-        %span.text-info= event.start_date.strftime("%a %b %d") + " - " + event.end_date.strftime("%a %b %d")
+          = link_to(event.name, event_path(event))
+        %span.text-info= event.date_range
 
         %h1
           = proposal.title

--- a/app/views/staff/events/show.html.haml
+++ b/app/views/staff/events/show.html.haml
@@ -11,7 +11,7 @@
             %strong= event.closes_at(:long_with_zone)
         %h1
           - if event.url?
-            = link_to event.name, "http://#{event.url}", target: 'blank', class: 'event-title'
+            = link_to event.name, "#{event.url}", target: 'blank', class: 'event-title'
           - else
             = event.name
         %h4

--- a/spec/features/current_event_user_flow_spec.rb
+++ b/spec/features/current_event_user_flow_spec.rb
@@ -71,11 +71,10 @@ feature "A user sees correct information for the current event and their role" d
       expect(page).to have_link(normal_user.name)
     end
 
-
     expect(page).to have_link(event_1.name)
     expect(page).to have_link(event_2.name)
 
-    click_on(event_1.name)
+    click_on("View #{event_1.name}'s Guidelines")
 
     within ".navbar" do
       expect(page).to have_link(event_1.name)
@@ -91,7 +90,7 @@ feature "A user sees correct information for the current event and their role" d
     end
 
     visit root_path
-    click_on(event_2.name)
+    click_on("View #{event_2.name}'s Guidelines")
 
     within ".navbar" do
       expect(page).to have_link(event_2.name)
@@ -130,8 +129,8 @@ feature "A user sees correct information for the current event and their role" d
     expect(page).to have_link(event_1.name)
     expect(page).to have_link(event_2.name)
 
-    click_on event_2.name
-    expect(current_path).to eq(event_path(event_2.slug))
+    click_on "View #{event_2.name}'s Guidelines"
+    expect(current_path).to eq(event_path(event_2))
 
     within ".navbar" do
       expect(page).to have_content(event_2.name)
@@ -140,7 +139,7 @@ feature "A user sees correct information for the current event and their role" d
     end
 
     visit root_path
-    click_on event_1.name
+    click_on "View #{event_1.name}'s Guidelines"
     expect(current_path).to eq(event_path(event_1.slug))
 
     within ".navbar" do

--- a/spec/features/current_event_user_flow_spec.rb
+++ b/spec/features/current_event_user_flow_spec.rb
@@ -19,37 +19,103 @@ feature "A user sees correct information for the current event and their role" d
     event_2 = create(:event, state: "closed")
 
     signin(normal_user.email, normal_user.password)
+    expect(current_path).to eq(event_path(event_1.slug))
 
     within ".navbar" do
       expect(page).to have_link(event_1.name)
+      expect(page).to_not have_link("My Proposals")
       expect(page).to have_link("", href: "/notifications")
       expect(page).to have_link(normal_user.name)
     end
 
-    expect(current_path).to eq(event_path(event_1.slug))
-
-    expect(page).to have_link(event_1.name)
-    expect(page).to_not have_link(event_2.name)
-
-    find("h1").click
-    expect(current_path).to eq(event_path(event_1.slug))
-    within ".navbar" do
-      expect(page).to have_content(event_1.name)
-      expect(page).to have_link("", href: "/notifications")
-      expect(page).to have_content(normal_user.name)
-      expect(page).to_not have_content("My Proposals")
+    within ".page-header" do
+      expect(page).to have_link(event_1.name)
+      expect(page).to_not have_link(event_2.name)
     end
 
     proposal = create(:proposal, :with_speaker)
     normal_user.proposals << proposal
     visit root_path
-    expect(page).to have_content("My Proposals")
+
+    within ".navbar" do
+      expect(page).to have_link("My Proposals")
+    end
+
+    visit proposals_path
+    within ".navbar" do
+      expect(page).to have_link(event_1.name)
+    end
+
+    visit notifications_path
+    within ".navbar" do
+      expect(page).to have_link(event_1.name)
+    end
+
+    visit profile_path
+    within ".navbar" do
+      expect(page).to have_link(event_1.name)
+    end
+  end
+
+  scenario "User flow for a speaker when there are two live events" do
+    event_1 = create(:event, state: "open")
+    event_2 = create(:event, state: "open")
+
+    signin(normal_user.email, normal_user.password)
+    expect(current_path).to eq(events_path)
+
+    within ".navbar" do
+      expect(page).to have_link("CFPApp")
+      expect(page).to_not have_link("My Proposals")
+      expect(page).to have_link("", href: "/notifications")
+      expect(page).to have_link(normal_user.name)
+    end
+
+
+    expect(page).to have_link(event_1.name)
+    expect(page).to have_link(event_2.name)
+
+    click_on(event_1.name)
+
+    within ".navbar" do
+      expect(page).to have_link(event_1.name)
+      expect(page).to_not have_link(event_2.name)
+      expect(page).to_not have_link("CFPApp")
+    end
+
+    visit root_path
+    visit proposals_path
+
+    within ".navbar" do
+      expect(page).to have_link(event_1.name)
+    end
+
+    visit root_path
+    click_on(event_2.name)
+
+    within ".navbar" do
+      expect(page).to have_link(event_2.name)
+    end
+
+    visit notifications_path
+
+    within ".navbar" do
+      expect(page).to have_link(event_2.name)
+    end
+
+    proposal = create(:proposal, :with_speaker)
+    normal_user.proposals << proposal
+
+    visit proposals_path
+
+    within ".navbar" do
+      expect(page).to have_link(event_2.name)
+    end
   end
 
   scenario "User flow for a speaker when there is no live event" do
     event_1 = create(:event, state: "closed")
     event_2 = create(:event, state: "closed")
-    proposal = create(:proposal, :with_speaker)
 
     signin(normal_user.email, normal_user.password)
 
@@ -71,14 +137,22 @@ feature "A user sees correct information for the current event and their role" d
       expect(page).to have_content(event_2.name)
       expect(page).to have_link("", href: "/notifications")
       expect(page).to have_content(normal_user.name)
-      expect(page).to_not have_content("My Proposals")
     end
 
-    normal_user.proposals << proposal
     visit root_path
+    click_on event_1.name
+    expect(current_path).to eq(event_path(event_1.slug))
+
+    within ".navbar" do
+      expect(page).to have_content(event_1.name)
+      expect(page).to have_link("", href: "/notifications")
+      expect(page).to have_content(normal_user.name)
+    end
+
   end
 
   scenario "User flow and navbar layout for a reviewer" do
+    pending
     event_1 = create(:event, state: "open")
     event_2 = create(:event, state: "open")
     proposal = create(:proposal, :with_reviewer_public_comment)
@@ -166,6 +240,7 @@ feature "A user sees correct information for the current event and their role" d
   end
 
   scenario "User flow for an admin" do
+    pending
     event_1 = create(:event, state: "open")
     event_2 = create(:event, state: "closed")
     proposal = create(:proposal, :with_organizer_public_comment)

--- a/spec/features/event_spec.rb
+++ b/spec/features/event_spec.rb
@@ -7,19 +7,19 @@ feature "Listing events for different roles" do
   let(:organizer) { create(:user) }
 
   context "As a regular user" do
-    scenario "the user should see a link to to the proposals for an event" do
+    scenario "the user should see a link to the guidelines page for an event" do
       login_as(normal_user)
       visit events_path
-      expect(page).to have_link('1 proposal', href: event_path(event.slug))
+      expect(page).to have_link("View #{event.name}'s Guidelines", href: event_path(event.slug))
     end
   end
 
   context "As an organizer" do
-    scenario "the organizer should see a link to the index for managing proposals" do
+    scenario "the organizer should see a link to the guidelines page for an event" do
       create(:event_teammate, role: 'organizer', user: organizer)
       login_as(organizer)
       visit events_path
-      expect(page).to have_link('1 proposal', href: event_staff_proposals_path(event))
+      expect(page).to have_link("View #{event.name}'s Guidelines", href: event_path(event.slug))
     end
   end
 

--- a/spec/features/event_teammate_invitation_spec.rb
+++ b/spec/features/event_teammate_invitation_spec.rb
@@ -11,7 +11,6 @@ feature 'EventTeammate Invitations' do
     it "can accept the invitation" do
       visit accept_event_teammate_invitation_path(invitation.slug, invitation.token)
       expect(page).to have_text('You successfully accepted the invitation')
-      expect(page).to have_text('0 proposals')
     end
 
     context "User receives incorrect or missing link in event_teammate invitation email" do

--- a/spec/features/staff/event_spec.rb
+++ b/spec/features/staff/event_spec.rb
@@ -30,13 +30,24 @@ feature "Event Dashboard" do
     it "can create a new event" do
       visit new_admin_event_path
       fill_in "Name", with: "My Other Event"
+      fill_in "Slug", with: "otherevent"
       fill_in "Contact email", with: "me@example.com"
       fill_in "Start date", with: DateTime.now + 10.days
       fill_in "End date", with: DateTime.now + 15.days
       fill_in "Closes at", with: DateTime.now + 15.days
-      click_button 'Save'
+      click_button "Save"
       admin_user.reload
       expect(admin_user.organizer_events.last.name).to eql("My Other Event")
+    end
+
+    it "must provide correct url syntax if a url is given" do
+      visit new_admin_event_path
+      fill_in "Name", with: "All About Donut Holes"
+      fill_in "Slug", with: "donutholes"
+      fill_in "URL", with: "www.donutholes.com"
+      click_button "Save"
+
+      expect(page).to have_content "must start with http:// or https://"
     end
 
     it "can edit an event" do


### PR DESCRIPTION
This PR implements a current_event session and the subsequent proper navbar flow for a speaker. In order to get current with newly created subnavs, I am stopping there and will make a separate PR for each different user role and their current_event/nav flow.

This PR also includes adding a custom validation method for event URLs, if the event creator chooses to provide one. 
