### PR TITLE
#93 Event info module

### DIFF
--- a/app/assets/stylesheets/base/_helper_classes.scss
+++ b/app/assets/stylesheets/base/_helper_classes.scss
@@ -40,3 +40,10 @@
 .brand-warning { color: $brand-warning; }
 .brand-danger { color: $brand-danger; }
 .brand-accent { color: $brand-accent; }
+
+.text-right-responsive,
+.text-center-responsive {
+  @media (max-width: 767px) {
+    text-align: left;
+  }
+}

--- a/app/assets/stylesheets/modules/_events.scss
+++ b/app/assets/stylesheets/modules/_events.scss
@@ -30,4 +30,92 @@
   }
 }
 
+$event-meta-padding: 10px;
 
+.event-info {
+  font-size: $font-size-base;
+
+  .event-title,
+  .event-meta {
+    display: inline-block;
+  }
+
+  .event-meta {
+    margin-left: $event-meta-padding;
+    color: $gray;
+  }
+}
+
+.event-info-block {
+  margin-bottom: $event-meta-padding * 2;
+
+  .event-title,
+  .event-meta {
+    display: block;
+  }
+  
+  .event-title {
+    font-size: $font-size-large;
+  }
+
+  .event-meta {
+    margin-top: $event-meta-padding / 2;
+    margin-left: 0;
+  }
+}
+
+// Builds on Bootstrap panels
+.event-info-panel {
+  & > .panel-heading {
+    font-size: $font-size-large;
+    text-transform: uppercase;
+  }
+
+  .event-label {
+    color: $gray;
+    font-weight: normal;
+  }
+
+  .event-callout {
+    font-size: $font-size-large;
+    margin-bottom: $event-meta-padding * 2;
+  }
+}
+
+// Event status badges
+$event-open-bg:       $state-success-bg;
+$event-open-border:   $state-success-border;
+$event-open-text:     $state-success-text;
+$event-closed-bg:     $gray-lighter;
+$event-closed-border: darken($gray-lighter, 7%);
+$event-closed-text:   $gray;
+$event-draft-bg:      $state-info-bg;
+$event-draft-border:  $state-info-border;
+$event-draft-text:    $state-info-text;
+
+.event-status-badge {
+  display: inline-block;
+  padding: $padding-xs-vertical $padding-xs-horizontal;
+  font-size: $font-size-small;
+  font-weight: bold;
+  line-height: 1.5;
+  text-transform: uppercase;
+
+  &.event-status-open {
+    background-color: $event-open-bg;
+    border: 1px solid $event-open-border;
+    color: $event-open-text;  
+  }
+
+  &.event-status-draft {
+    background-color: $event-draft-bg;
+    border: 1px solid $event-draft-border;
+    color: $event-draft-text;  
+  }
+
+  &.event-status-closed {
+    background-color: $event-closed-bg;
+    border: 1px solid $event-closed-border;
+    color: $event-closed-text;  
+  }
+}

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -10,6 +10,17 @@
 
 .row.margin-top
   .col-md-8
+    .event-info.event-info-block
+      %strong.event-title= event.name  
+      - if event.start_date? && event.end_date?
+        .event-meta
+          %i.fa.fa-fw.fa-calendar
+          = event.date_range
+      - if event.url?
+        %span.event-meta= link_to event.url
+      - if event.contact_email?
+        %span.event-meta= mail_to(event.contact_email)
+
     .markdown
       - if event.closed?
         Closed on
@@ -17,25 +28,36 @@
       = markdown(event.guidelines)
 
   .col-md-4
+
     - if event.open?
+      .panel.panel-success.event-info.event-info-panel
+        .panel-heading
+          CFP
+          = event.status
+        .panel-body
+          - if event.closes_at?
+            %dl
+              %dt.event-label
+                CFP closes: 
+              %dd.event-callout
+                = event.closes_at(:long_with_zone)
+              %dd
+                %strong= time_ago_in_words(event.closes_at)
+                left to submit your proposal
+          %div
+            = link_to 'Submit a proposal', new_event_proposal_path, class: 'btn btn-primary'
+    - else
+      .panel.panel-default
+        .panel-heading
+          CFP
+          = event.status
+        .panel-body
+          %dl.event-cfp-data
+            %dt
+              CFP closed: 
+            %dd
+              = event.closes_at(:long_with_zone)
 
-      .pull-right= link_to 'Submit a proposal', new_event_proposal_path, class: 'btn btn-primary btn-xlarge'
-
-      - if event.closes_at?
-        %h4.pull-right
-          Closes at
-          %strong= event.closes_at(:long_with_zone)
-        %h4.pull-right
-          %strong
-            %span.label.label-info
-              = time_ago_in_words(event.closes_at)
-              left
-          &nbsp;to submit your proposal!
-
-        %h4.pull-right
-          %span.label.label-default
-            = pluralize(event.proposals.count, 'proposal')
-            submitted
 
     - if event.proposals.count > 5
       .stats

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -3,10 +3,8 @@
     .page-header
       .share.pull-right= event.tweet_button
       %h1
-        - if event.url?
-          = link_to event.name, "#{event.url}", target: 'blank', class: 'event-title'
-        - else
-          = event.name
+        = event.name 
+        Call for Proposals
 
 .row.margin-top
   .col-md-8

--- a/app/views/pages/current_styleguide.html.haml
+++ b/app/views/pages/current_styleguide.html.haml
@@ -28,6 +28,8 @@
               %a{"data-toggle" => "tab", :href => "#shortcuts-example"} Shortcuts / Stats
             %li
               %a{"data-toggle" => "tab", :href => "#cal-news-example"} Calendar / News
+            %li
+              %a{"data-toggle" => "tab", :href => "#ui-components"} UI Elements
 
 
           .tab-content
@@ -675,6 +677,48 @@
                             %a.name Mark Jobs
                             %span.time 2 Days ago
                           .text That's the ONLY thing about being a slave. Now, now. Perfectly symmetrical violence never solved anything. Uh, is the puppy mechanical in any way? As an interesting side note, as a head without a body, I envy the dead.
+
+            #ui-components.tab-pane
+              %h3 Event Info
+              
+              .row
+                .col-md-4
+                  .event-info.event-info-dense
+                    %strong.event-title SeedConf
+                    %span.event-meta 
+                      %i.fa.fa-fw.fa-calendar
+                      March 13, 2017
+                    %span.event-meta 
+                      %i.fa.fa-fw.fa-map-marker
+                      Phoenix, AZ
+                .col-md-4
+                  .event-info.event-info-block
+                    %strong.event-title SeedConf
+                    %span.event-meta 
+                      %i.fa.fa-fw.fa-calendar
+                      March 13, 2017
+                    %span.event-meta 
+                      %i.fa.fa-fw.fa-map-marker
+                      Phoenix, AZ
+                    %span.event-meta= link_to("http://seedconf.com")
+                    %span.event-meta= mail_to("contact@seed.event")
+                .col-md-4
+                  .panel.panel-success.event-info.event-info-panel
+                    .panel-heading
+                      CFP OPEN
+                    .panel-body
+                      %dl
+                        %dt.event-label CFP closes: 
+                        %dd.event-callout January 7, 2017 at 09:30pm MST
+                        %dd
+                          %strong 6 months left to submit your proposal
+                      %div
+                        = link_to 'Submit a proposal', '#', class: 'btn btn-primary'
+              %h3 Event Status Badges
+              
+              .event-status-badge.event-status-open CFP OPEN
+              .event-status-badge.event-status-closed CFP CLOSED
+              .event-status-badge.event-status-draft CFP DRAFT
 
 :javascript
   $(document).ready(function() {

--- a/app/views/proposals/edit.html.haml
+++ b/app/views/proposals/edit.html.haml
@@ -1,10 +1,27 @@
-.row
-  .col-md-12
-    .page-header
+.page-header
+  .row
+    .col-md-12
       %h1
         Edit
         %em #{proposal.title}
         for #{event}
+  .row
+    .col-md-8
+      .event-info.event-info-dense
+        %strong.event-title= event.name
+        - if event.start_date? && event.end_date?
+          %span.event-meta 
+            %i.fa.fa-fw.fa-calendar
+            = event.date_range
+    .col-md-4.text-right.text-right-responsive
+      .event-info.event-info-dense
+        %span{:class => "event-meta event-status-badge event-status-#{event.status}"}
+          CFP 
+          = event.status
+        - if event.open?
+          %span.event-meta
+            CFP closes:
+            %strong= event.closes_at(:month_day_year)
 
 = simple_form_for [event, proposal], url: event_proposal_path(event.slug, proposal) do |f|
   = render partial: 'form', locals: {f: f}

--- a/app/views/proposals/index.html.haml
+++ b/app/views/proposals/index.html.haml
@@ -11,35 +11,19 @@
 
       .row
         .col-md-7
-          %h1.inline-block
-            - if event.url?
-              = link_to event.name, "#{event.url}", target: 'blank', class: 'event-title'
-            - else
-              = event.name
-
-          %span= link_to 'View Guidelines', event_path(event.slug), class: 'guidelines-link'
-
-          %h4.margin-bottom
-            = event.date_range
-
-        .col-md-5.margin-top
-          - if event.open?
-            %p.pull-right= link_to 'Submit a proposal', new_event_proposal_path(event_slug: event.slug), class: 'btn btn-primary btn-md'
-
-            - if event.closes_at?
-              %p.pull-right
-                Closes at
-                %strong= event.closes_at(:long_with_zone)
-              %p.pull-right
-                %strong
-                  %span.label.label-info
-                    = time_ago_in_words(event.closes_at)
-                    left
-                &nbsp;to submit your proposal!
-
-            %span.label.label-default.pull-right
-              = pluralize(event.proposals.count, 'proposal')
-              submitted
+          .event-info.event-info-block
+            %strong.event-title= event.name
+            .event-meta
+              - if event.start_date? && event.end_date?
+                %span.event-meta-item 
+                  %i.fa.fa-fw.fa-calendar
+                  = event.date_range
+            .event-meta
+              %span{:class => "event-status-badge event-status-#{event.status}"}
+                CFP 
+                = event.status
+              %span.event-meta
+                = link_to 'View Guidelines', event_path(event.slug)
 
       .row
         .col-md-12

--- a/app/views/proposals/new.html.haml
+++ b/app/views/proposals/new.html.haml
@@ -3,15 +3,32 @@
     .col-md-12
       %h1 New Proposal for #{event}
   .row
-    .col-md-6
-      %p
-        Read the <strong>#{link_to 'guidelines', event_path(event.slug)}</strong> to maximize
-        your chance of approval. Refrain from including any information that
-        would allow a reviewer to identify you.
-      %p
-        All fields support
-        %a{href: 'https://help.github.com/articles/github-flavored-markdown'}
-          %strong GitHub Flavored Markdown.
+    .col-md-8
+      .event-info.event-info-dense
+        %strong.event-title= event.name
+        - if event.start_date? && event.end_date?
+          %span.event-meta 
+            %i.fa.fa-fw.fa-calendar
+            = event.date_range
+    .col-md-4.text-right.text-right-responsive
+      .event-info.event-info-dense
+        %span{:class => "event-meta event-status-badge event-status-#{event.status}"}
+          CFP 
+          = event.status
+        - if event.open?
+          %span.event-meta
+            CFP closes:
+            %strong= event.closes_at(:month_day_year)
+.row
+  .col-md-6
+    %p
+      Read the <strong>#{link_to 'guidelines', event_path(event.slug)}</strong> to maximize
+      your chance of approval. Refrain from including any information that
+      would allow a reviewer to identify you.
+    %p
+      All fields support
+      %a{href: 'https://help.github.com/articles/github-flavored-markdown'}
+        %strong GitHub Flavored Markdown.
 
 = simple_form_for proposal, url: event_proposals_path(event) do |f|
   = render partial: 'form', locals: {f: f}

--- a/app/views/proposals/show.html.haml
+++ b/app/views/proposals/show.html.haml
@@ -2,18 +2,8 @@
   .page-header
     .row
       .col-md-8
-        %h3
-          = link_to(event.name, event_path(event))
-        %span.text-info= event.date_range
-
         %h1
           = proposal.title
-          %small
-            = proposal.session_format.try(:name)
-            - if proposal.track
-              \ –
-              = proposal.track.name
-
       .col-md-4
         - if proposal.has_speaker?(current_user)
           .toolbox.pull-right
@@ -28,11 +18,32 @@
                   = link_to event_proposal_path, method: :delete, data: {confirm: 'This will delete your talk. Are you sure you want to do this? It can not be undone.'}, class: 'btn btn-warning', id: 'delete' do
                     %span.glyphicon.glyphicon-exclamation-sign
                     Delete Proposal
-            %p.text-info.margin-top
-              CFP closes
-              = event.closes_at(:month_day_year)
     .row
-      .col-md-12.tags= proposal.tags
+      .col-md-8
+        .event-info.event-info-dense
+          %strong.event-title= event.name
+          - if event.start_date? && event.end_date?
+            %span.event-meta
+              %i.fa.fa-fw.fa-calendar
+              = event.date_range
+      .col-md-4.text-right.text-right-responsive
+        .event-info.event-info-dense
+          %span{:class => "event-meta event-status-badge event-status-#{event.status}"}
+            CFP 
+            = event.status
+          - if event.open?
+            %span.event-meta
+              CFP closes:
+              %strong= event.closes_at(:month_day_year)
+  .row
+    .col-md-12
+      %small
+        = proposal.session_format.try(:name)
+        - if proposal.track
+          \ –
+          = proposal.track.name
+  .row
+    .col-md-12.tags= proposal.tags
 
   .row
     .col-md-4

--- a/spec/features/current_event_user_flow_spec.rb
+++ b/spec/features/current_event_user_flow_spec.rb
@@ -29,8 +29,8 @@ feature "A user sees correct information for the current event and their role" d
     end
 
     within ".page-header" do
-      expect(page).to have_link(event_1.name)
-      expect(page).to_not have_link(event_2.name)
+      expect(page).to have_content("#{event_1.name} Call for Proposals")
+      expect(page).to_not have_content("#{event_2.name} Call for Proposals")
     end
 
     proposal = create(:proposal, :with_speaker)


### PR DESCRIPTION
Addresses card #93 (decided to lump event info and CFP info together as they are related). This PR only touches the speaker flow; the organizer views will be a separate PR.
- Adds a "mini" event bar containing event and CFP info to the proposal show/edit/create pages
- Adds an event block to the event guidelines page and the proposal index page
- Adds a CFP info panel to the event guidelines page
- Removed event url from the page heading on event guidelines (URL is displayed in info block)
#### Notes
- I don't know how to set up speaker invitations, and I know they are being worked on now. I believe that some form of event info should show up in the invitation as well.
#### Screenshots:

![screen shot 2016-07-13 at 6 32 07 pm](https://cloud.githubusercontent.com/assets/522911/16822108/55628334-4928-11e6-902f-fd3d1fcc6ca4.png)

![screen shot 2016-07-13 at 6 32 25 pm](https://cloud.githubusercontent.com/assets/522911/16822133/744f1528-4928-11e6-82ac-a29ac94051e9.png)

![screen shot 2016-07-13 at 6 31 34 pm](https://cloud.githubusercontent.com/assets/522911/16822116/62ce83b0-4928-11e6-9b45-22ff2aa0228f.png)

![screen shot 2016-07-13 at 6 30 30 pm](https://cloud.githubusercontent.com/assets/522911/16822138/8076c74c-4928-11e6-8b95-ff90ecbd52ca.png)

![screen shot 2016-07-13 at 6 30 10 pm](https://cloud.githubusercontent.com/assets/522911/16822170/ad716432-4928-11e6-831b-4ff9aaf108c0.png)

@mghaught @rylanb @mbburch @PenneyGadget 
