### PR TITLE
#96 Update proposal pages

### DIFF
--- a/app/assets/stylesheets/base/_layout.scss
+++ b/app/assets/stylesheets/base/_layout.scss
@@ -7,3 +7,19 @@ body {
   margin-left: auto;
   margin-right: auto;
 }
+
+.page-header {
+  &.page-header-slim {
+    margin-top: 20px;
+  }
+
+  h1 {
+    margin-bottom: 0;
+  }
+
+  // force page-header actions to sit bottom-flush with h1 for now
+  // until a page-header refactor using flexbox or display: table
+  .toolbox {
+    margin-top: 28px;
+  }
+}

--- a/app/assets/stylesheets/base/_layout.scss
+++ b/app/assets/stylesheets/base/_layout.scss
@@ -22,4 +22,8 @@ body {
   .toolbox {
     margin-top: 28px;
   }
+
+  .label {
+    vertical-align: middle;
+  }
 }

--- a/app/assets/stylesheets/modules/_comments.scss
+++ b/app/assets/stylesheets/modules/_comments.scss
@@ -1,11 +1,5 @@
-.comment {
-  border: 0 solid #ddd;
-  border-left-width: 5px;
-  padding-left: 0.5em;
-  margin-bottom: 0.5em;
-}
 
-.speaker-comment {
+.speaker-comment .message_wrap {
   border-color: #9ACFEA;
 }
 

--- a/app/assets/stylesheets/modules/_discussions.scss
+++ b/app/assets/stylesheets/modules/_discussions.scss
@@ -5,15 +5,24 @@ ul.messages_layout {
   position: relative;
 }
 ul.messages_layout li {
-  float: left;
   list-style: none;
-  position: relative
+  position: relative;
+
+  &:before,
+  &:after {
+    content: "";
+    display: table;
+  }
+
+  &:after {
+    clear: both;
+  }
 }
 ul.messages_layout li.left {
-  padding-left: 75px
+  padding-left: 35px
 }
 ul.messages_layout li.right {
-  padding-right: 75px
+  padding-right: 35px
 }
 ul.messages_layout li.right .avatar {
   right: 0;
@@ -44,8 +53,9 @@ ul.messages_layout li a.avatar img {
 }
 ul.messages_layout li .message_wrap {
   background: #fefefe;
-  border: 1px solid $brand-primary;
+  border: 1px solid $gray-light;
   float: left;
+  width: 100%;
   margin-bottom: 20px;
   padding: 10px;
   position: relative;
@@ -67,10 +77,19 @@ ul.messages_layout li .message_wrap .arrow {
   top: 13px
 }
 ul.messages_layout li .message_wrap .info {
-  float: left;
   width: 100%;
   border-bottom: 1px solid #fff;
-  line-height: 23px
+  line-height: 23px;
+
+  &:before,
+  &:after {
+    content: "";
+    display: table;
+  }
+
+  &:after {
+    clear: both;
+  }
 }
 ul.messages_layout li .message_wrap .info .name {
   color: $brand-primary;
@@ -83,7 +102,6 @@ ul.messages_layout li .message_wrap .info .time {
   margin-left: 6px
 }
 ul.messages_layout li .message_wrap .text {
-  float: left;
   width: 100%;
   border-top: 1px solid #cfcfcf;
   padding-top: 5px

--- a/app/assets/stylesheets/modules/_events.scss
+++ b/app/assets/stylesheets/modules/_events.scss
@@ -38,6 +38,10 @@
 
 $event-meta-padding: 10px;
 
+.event-info-bar {
+  margin-top: 20px;
+}
+
 .event-info {
   font-size: $font-size-base;
 

--- a/app/assets/stylesheets/modules/_forms.scss
+++ b/app/assets/stylesheets/modules/_forms.scss
@@ -40,6 +40,15 @@ span[title="required"] {
   color: darken(#edd1d1, 50%);
 }
 
+.control-label {
+  display: block;
+  max-width: 100%;
+  margin-bottom: 5px;
+  margin-top: 0;
+  font-size: $font-size-base;
+  font-weight: bold;
+}
+
 .cancel-form {
   margin-right: .5em;
 }

--- a/app/assets/stylesheets/modules/_labels.scss
+++ b/app/assets/stylesheets/modules/_labels.scss
@@ -21,3 +21,7 @@
 .label-danger {
   @include label-variant($label-danger-bg);
 }
+
+.label-mini {
+  font-size: $font-size-small;
+}

--- a/app/assets/stylesheets/modules/_proposal.scss
+++ b/app/assets/stylesheets/modules/_proposal.scss
@@ -8,12 +8,12 @@
   }
 }
 
-.proposal {
+.proposal,
+.proposal-section {
   margin-bottom: 1em;
 }
+
 .speaker {
-  border-bottom: 1px solid $gray-light;
-  margin-top: 1em;
   > h1, > h2, > h3, > h4 {
     margin-top: 0;
   }

--- a/app/assets/stylesheets/modules/_proposal.scss
+++ b/app/assets/stylesheets/modules/_proposal.scss
@@ -134,10 +134,6 @@ div.col-md-4 {
   margin-top: 10px;
 }
 
-.new-speaker-invite {
-  margin-top: 20px;
-}
-
 .speaker-invite-form {
   display: none;
   form {

--- a/app/assets/stylesheets/modules/_widgets.scss
+++ b/app/assets/stylesheets/modules/_widgets.scss
@@ -115,3 +115,38 @@
     background: #FFF;
   }
 }
+
+.widget-card {
+  background: #f9f6f1;
+  padding: 15px;
+
+  .widget-header,
+  .widget-content {
+    background: #f9f6f1;
+    border: none;
+    border-radius: 0;
+    padding: 15px 0;
+  }
+
+  .widget-header {
+    border-bottom: 1px solid #ccc;
+    height: auto;
+    line-height: 1;
+
+    > [class^="fa-"], > [class*=" fa-"],
+    > [class^="glyphicon-"], > [class*=" glyphicon-"] {
+      margin: 0;
+    }
+
+    h3 {
+      margin: 0;
+      top: auto;
+      left: auto;
+      line-height: 1;
+    }
+  }
+}
+
+.widget-card {
+  margin: 0;
+}

--- a/app/assets/stylesheets/modules/_widgets.scss
+++ b/app/assets/stylesheets/modules/_widgets.scss
@@ -146,7 +146,3 @@
     }
   }
 }
-
-.widget-card {
-  margin: 0;
-}

--- a/app/decorators/proposal_decorator.rb
+++ b/app/decorators/proposal_decorator.rb
@@ -95,7 +95,8 @@ class ProposalDecorator < ApplicationDecorator
 
     classes = "label #{state_class(state)}"
     classes += ' status' unless small
-
+    classes += ' label-mini' if small
+    
     state += ' & confirmed' if proposal.confirmed? && show_confirmed
 
     h.content_tag :span, state, class: classes

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -1,11 +1,11 @@
 module CommentsHelper
   def choose_class_for(comment)
     if comment.proposal.has_speaker?(comment.user)
-      'speaker-comment'
+      'by_myself right speaker-comment'
     elsif comment.user.organizer_for_event?(comment.proposal.event)
-      'organizer-comment'
+      'from_user left organizer-comment'
     elsif comment.user.reviewer_for_event?(comment.proposal.event)
-      'reviewer-comment'
+      'from_user left reviewer-comment'
     end
   end
 end

--- a/app/views/proposals/_comments.html.haml
+++ b/app/views/proposals/_comments.html.haml
@@ -1,13 +1,17 @@
-%p.count
-  = pluralize(comments.count, 'comment')
-- comments.order(:created_at).each do |comment|
-  .comment.markdown{ class: choose_class_for(comment) }
-    =markdown(comment.body)
+%ul.messages_layout
+  - comments.order(:created_at).each do |comment|
+    %li.comment.markdown{ class: choose_class_for(comment) }
+      %a.avatar
+        = image_tag("https://www.gravatar.com/avatar/#{comment.user.gravatar_hash}?s=25")
+      .message_wrap
+        - if comment.user.present?
+          .info{ title: comment.created_at.to_s }
+            %a.name #{proposal.has_speaker?(comment.user) ? 'speaker' : comment.user.name}
+            %span.time #{comment.created_at.to_s(:day_at_time)}
+        .text
+          =markdown(comment.body)
 
-    - if comment.user.present?
-      .meta
-        %small{ title: comment.created_at.to_s }
-          #{proposal.has_speaker?(comment.user) ? 'speaker' : comment.user.name} - #{comment.created_at.to_s(:day_at_time)}
+      
 
 = form_for comments.new do |f|
   = f.hidden_field :proposal_id

--- a/app/views/proposals/_contents.html.haml
+++ b/app/views/proposals/_contents.html.haml
@@ -1,23 +1,40 @@
-%h3 Title
-.markdown{ data: { 'field-id' => 'proposal_title' } }
-  = proposal.title
+.proposal-section
+  %h3 Title
+  .markdown{ data: { 'field-id' => 'proposal_title' } }
+    = proposal.title
 
-%h3 Abstract
-.markdown{ data: { 'field-id' => 'proposal_abstract' } }
-  = proposal.abstract
+.proposal-section
+  %h3 Session Format
+  = proposal.session_format.try(:name)
 
-%h3 Details
-.markdown{ data: { 'field-id' => 'proposal_details' } }
-  = proposal.details
+- if proposal.track
+  .proposal-section
+    %h3 Track
+    = proposal.track.name
 
-%h3 Pitch
-.markdown{ data: { 'field-id' => 'proposal_pitch' } }
-  =proposal.pitch
+.proposal-section
+  %h3 Abstract
+  .markdown{ data: { 'field-id' => 'proposal_abstract' } }
+    = proposal.abstract
 
-  - if proposal.custom_fields.any?
-    - proposal.proposal_data[:custom_fields].select do |key,value|
+.proposal-section
+  %h3 Tags
+  = proposal.tags
+
+.proposal-section
+  %h3 Details
+  .markdown{ data: { 'field-id' => 'proposal_details' } }
+    = proposal.details
+
+.proposal-section
+  %h3 Pitch
+  .markdown{ data: { 'field-id' => 'proposal_pitch' } }
+    =proposal.pitch
+
+- if proposal.custom_fields.any?
+  - proposal.proposal_data[:custom_fields].select do |key,value|
+    .proposal-section
       %h3= key.capitalize
       %div
       = value.capitalize
       %div
-

--- a/app/views/proposals/_form.html.haml
+++ b/app/views/proposals/_form.html.haml
@@ -1,5 +1,5 @@
 .row
-  .col-md-6
+  .col-md-8
     %fieldset
       = proposal.title_input(f)
 
@@ -51,7 +51,4 @@
       .form-submit.clearfix
         %button.pull-right.btn.btn-primary.btn-lg{type: "submit"} Save
 
-  .col-md-6
-    %fieldset
-      = render partial: 'preview', locals: { proposal: proposal }
 

--- a/app/views/proposals/_form.html.haml
+++ b/app/views/proposals/_form.html.haml
@@ -1,54 +1,50 @@
-.row
-  .col-md-8
-    %fieldset
-      = proposal.title_input(f)
 
-      - opts_session_formats = event.session_formats.publicly_viewable.map {|st| [st.name, st.id]}
+%fieldset
+  %legend Proposal Details
+  = proposal.title_input(f)
 
-      - if opts_session_formats.length > 1
-        = f.association :session_format, collection: opts_session_formats, include_blank: 'None selected', required: true, input_html: {class: 'dropdown'}, hint: "Session Format Hint", tooltip: ["right", session_format_tooltip]
-      - else
-        = f.association :session_format, collection: opts_session_formats, include_blank: false, input_html: {readonly: "readonly"}, hint: "Session Format Hint", tooltip: ["right", "Only One Session Format for #{event.name}"]
+  - opts_session_formats = event.session_formats.publicly_viewable.map {|st| [st.name, st.id]}
 
-      - opts_tracks = event.tracks.map {|t| [t.name, t.id]}
-      -if opts_tracks.length > 0
-        = f.association :track, collection: opts_tracks, include_blank: 'None selected', input_html: {class: 'dropdown'}, hint: "Track Hint", tooltip: ["right", track_tooltip]
+  - if opts_session_formats.length > 1
+    = f.association :session_format, collection: opts_session_formats, include_blank: 'None selected', required: true, input_html: {class: 'dropdown'}, hint: "Session Format Hint", tooltip: ["right", session_format_tooltip]
+  - else
+    = f.association :session_format, collection: opts_session_formats, include_blank: false, input_html: {readonly: "readonly"}, hint: "Session Format Hint", tooltip: ["right", "Only One Session Format for #{event.name}"]
 
-      = proposal.abstract_input(f, abstract_tooltip)
+  - opts_tracks = event.tracks.map {|t| [t.name, t.id]}
+  -if opts_tracks.length > 0
+    = f.association :track, collection: opts_tracks, include_blank: 'None selected', input_html: {class: 'dropdown'}, hint: "Track Hint", tooltip: ["right", track_tooltip]
 
-      %hr/
-      %h3 For Review Committee
-      %p.help-block
-        This content will <strong> only</strong> be visible to the review committee.
+  = proposal.abstract_input(f, abstract_tooltip)
 
-      = f.input :details, input_html: { class: 'watched', rows: 5 },
-        placeholder: 'Explain the theme and flow of your talk. What are the intended audience takeaways?',
-        hint: 'Include any pertinent details such as outlines, outcomes or intended audience.', tooltip: ["right", details_tooltip]
+  - if event.proposal_tags.any?
+    .form-group
+      %h3.control-label Tags
+      = f.select :tags,
+        options_for_select(event.proposal_tags, proposal.object.tags),
+        {}, {class: 'multiselect proposal-tags', multiple: true }
 
-      = f.input :pitch, input_html: { class: 'watched', rows: 5 },
-        placeholder: 'Why is this talk pertinent? What is your involvement in the topic?',
-        hint: 'Explain why this talk should be considered and what makes you qualified to speak on the topic.', tooltip: ["right", pitch_tooltip]
+%fieldset
+  %legend For Review Committee
+  %p
+    This content will <strong> only</strong> be visible to the review committee.
 
-      %hr/
+  = f.input :details, input_html: { class: 'watched', rows: 5 },
+    placeholder: 'Explain the theme and flow of your talk. What are the intended audience takeaways?',
+    hint: 'Include any pertinent details such as outlines, outcomes or intended audience.', tooltip: ["right", details_tooltip]
 
-      - if event.proposal_tags.any?
-        %h3 Tags
-        %p.help-block I think this goes away ?
-        = f.select :tags,
-          options_for_select(event.proposal_tags, proposal.object.tags),
-          {}, {class: 'multiselect proposal-tags', multiple: true }
+  = f.input :pitch, input_html: { class: 'watched', rows: 5 },
+    placeholder: 'Why is this talk pertinent? What is your involvement in the topic?',
+    hint: 'Explain why this talk should be considered and what makes you qualified to speak on the topic.', tooltip: ["right", pitch_tooltip]
 
-      - if event.custom_fields.any?
-        %h3 Custom Fields
-        %p.help-block Custom Fields Helper
-        - event.custom_fields.each do |custom_field|
-          .form-group
-            = f.label custom_field
-            = text_field_tag "proposal[custom_fields][#{custom_field}]", proposal.custom_fields[custom_field], class: "form-control"
+- if event.custom_fields.any?
+  - event.custom_fields.each do |custom_field|
+    .form-group
+      = f.label custom_field
+      = text_field_tag "proposal[custom_fields][#{custom_field}]", proposal.custom_fields[custom_field], class: "form-control"
 
-      = render partial: 'speakers/fields', locals: { f: f }
+= render partial: 'speakers/fields', locals: { f: f }
 
-      .form-submit.clearfix
-        %button.pull-right.btn.btn-primary.btn-lg{type: "submit"} Save
+.form-submit.clearfix
+  %button.pull-right.btn.btn-primary.btn-lg{type: "submit"} Save
 
 

--- a/app/views/proposals/_preview.html.haml
+++ b/app/views/proposals/_preview.html.haml
@@ -1,7 +1,5 @@
-#proposal-preview.panel.panel-default{ data: { 'remote-url' => event_parse_edit_field_proposal_path(event.slug) } }
-  .panel-heading
-    %h2.panel-title
-      %i.fa.fa-eye
-      Preview
-  .panel-body
-    = render partial: 'proposals/contents', locals: { proposal: proposal }
+.row
+  .col-md-8
+    #proposal-preview{ data: { 'remote-url' => event_parse_edit_field_proposal_path(event.slug) } }
+
+      = render partial: 'proposals/contents', locals: { proposal: proposal }

--- a/app/views/proposals/edit.html.haml
+++ b/app/views/proposals/edit.html.haml
@@ -1,10 +1,4 @@
-.page-header
-  .row
-    .col-md-12
-      %h1
-        Edit
-        %em #{proposal.title}
-        for #{event}
+.event-info-bar
   .row
     .col-md-8
       .event-info.event-info-dense
@@ -22,6 +16,37 @@
           %span.event-meta
             CFP closes:
             %strong= event.closes_at(:month_day_year)
+            
+.page-header.page-header-slim
+  .row
+    .col-md-12
+      %h1
+        Edit
+        %em #{proposal.title}
+        for #{event}
 
-= simple_form_for [event, proposal], url: event_proposal_path(event.slug, proposal) do |f|
-  = render partial: 'form', locals: {f: f}
+.row
+  .col-md-12
+    .tabbable
+      %ul.nav.nav-tabs
+        %li.active
+          %a{"data-toggle" => "tab", :href => "#edit-proposal"} Edit proposal
+        %li
+          %a{"data-toggle" => "tab", :href => "#preview"} Preview
+      .tab-content
+        #edit-proposal.tab-pane.active
+          .row
+            .col-md-8
+              %p
+                Read the <strong>#{link_to 'guidelines', event_path(event.slug)}</strong> to maximize
+                your chance of approval. Refrain from including any information that
+                would allow a reviewer to identify you.
+              %p
+                All fields support
+                %a{href: 'https://help.github.com/articles/github-flavored-markdown'}
+                  %strong GitHub Flavored Markdown.
+
+              = simple_form_for [event, proposal], url: event_proposal_path(event.slug, proposal) do |f|
+                = render partial: 'form', locals: {f: f}
+        #preview.tab-pane
+          = render partial: 'preview', locals: { proposal: proposal }

--- a/app/views/proposals/new.html.haml
+++ b/app/views/proposals/new.html.haml
@@ -1,7 +1,4 @@
-.page-header
-  .row
-    .col-md-12
-      %h1 New Proposal for #{event}
+.event-info-bar
   .row
     .col-md-8
       .event-info.event-info-dense
@@ -19,6 +16,12 @@
           %span.event-meta
             CFP closes:
             %strong= event.closes_at(:month_day_year)
+
+.page-header.page-header-slim
+  .row
+    .col-md-12
+      %h1 New Proposal for #{event}
+
 .row
   .col-md-12
     .tabbable

--- a/app/views/proposals/new.html.haml
+++ b/app/views/proposals/new.html.haml
@@ -20,15 +20,27 @@
             CFP closes:
             %strong= event.closes_at(:month_day_year)
 .row
-  .col-md-6
-    %p
-      Read the <strong>#{link_to 'guidelines', event_path(event.slug)}</strong> to maximize
-      your chance of approval. Refrain from including any information that
-      would allow a reviewer to identify you.
-    %p
-      All fields support
-      %a{href: 'https://help.github.com/articles/github-flavored-markdown'}
-        %strong GitHub Flavored Markdown.
+  .col-md-12
+    .tabbable
+      %ul.nav.nav-tabs
+        %li.active
+          %a{"data-toggle" => "tab", :href => "#create-proposal"} Create proposal
+        %li
+          %a{"data-toggle" => "tab", :href => "#preview"} Preview
+      .tab-content
+        #create-proposal.tab-pane.active
+          .row
+            .col-md-8
+              %p
+                Read the <strong>#{link_to 'guidelines', event_path(event.slug)}</strong> to maximize
+                your chance of approval. Refrain from including any information that
+                would allow a reviewer to identify you.
+              %p
+                All fields support
+                %a{href: 'https://help.github.com/articles/github-flavored-markdown'}
+                  %strong GitHub Flavored Markdown.
 
-= simple_form_for proposal, url: event_proposals_path(event) do |f|
-  = render partial: 'form', locals: {f: f}
+              = simple_form_for proposal, url: event_proposals_path(event) do |f|
+                = render partial: 'form', locals: {f: f}
+        #preview.tab-pane
+          = render partial: 'preview', locals: { proposal: proposal }

--- a/app/views/proposals/show.html.haml
+++ b/app/views/proposals/show.html.haml
@@ -67,17 +67,20 @@
                       disabled: !invitation.pending?,
                       data: {confirm: 'Are you sure you want to remove this invitation?'}
           .new-speaker-invite
-            %p You may invite other speakers to your proposal.
-            .button.btn.btn-success.speaker-invite-button Invite a Speaker
+            %p
+              You may invite other speakers to your proposal.
+              %button.button.btn.btn-success.btn-xs.speaker-invite-button 
+                Invite a Speaker
             .speaker-invite-form
-              = form_tag invitations_path(proposal_uuid: proposal.uuid), class: 'form-horizontal speaker' do
-                %h3 Invite a Speaker
-                .input-group{role: "group", "aria-label" => "Enter an Email to Invite a Speaker"}
-                  = email_field_tag :email, '', placeholder: "Enter an email address.", class: 'form-control'
-                  %span.input-group-btn
-                    %button.btn.btn-success(type="submit")
-                      %span.glyphicon.glyphicon-envelope
-                      Invite
+              = form_tag invitations_path(proposal_uuid: proposal.uuid), class: 'speaker' do
+                .widget.widget-card
+                  %h3.control-label Invite a Speaker
+                  .input-group{role: "group", "aria-label" => "Enter an Email to Invite a Speaker"}
+                    = email_field_tag :email, '', placeholder: "Enter an email address.", class: 'form-control'
+                    %span.input-group-btn
+                      %button.btn.btn-success(type="submit")
+                        %span.glyphicon.glyphicon-envelope
+                        Invite
 
     .col-md-4
       .widget.widget-card

--- a/app/views/proposals/show.html.haml
+++ b/app/views/proposals/show.html.haml
@@ -79,7 +79,7 @@
                       Invite
 
     .col-md-4
-      .widget
+      .widget.widget-card
         .widget-header
           %i.fa.fa-sticky-note-o
           %h3 Reviewer Activity
@@ -90,7 +90,7 @@
       .widget
         .widget-header
           %i.fa.fa-comments
-          %h3 Comments
+          %h3= pluralize(proposal.public_comments.count, 'comment')
         .widget-content
           = render partial: 'proposals/comments',
             locals: { proposal: proposal, comments: proposal.public_comments }

--- a/app/views/proposals/show.html.haml
+++ b/app/views/proposals/show.html.haml
@@ -1,5 +1,24 @@
+.event-info-bar
+  .row
+    .col-md-8
+      .event-info.event-info-dense
+        %strong.event-title= event.name
+        - if event.start_date? && event.end_date?
+          %span.event-meta
+            %i.fa.fa-fw.fa-calendar
+            = event.date_range
+    .col-md-4.text-right.text-right-responsive
+      .event-info.event-info-dense
+        %span{:class => "event-meta event-status-badge event-status-#{event.status}"}
+          CFP 
+          = event.status
+        - if event.open?
+          %span.event-meta
+            CFP closes:
+            %strong= event.closes_at(:month_day_year)
+            
 #proposal
-  .page-header
+  .page-header.page-header-slim
     .row
       .col-md-8
         %h1
@@ -18,81 +37,47 @@
                   = link_to event_proposal_path, method: :delete, data: {confirm: 'This will delete your talk. Are you sure you want to do this? It can not be undone.'}, class: 'btn btn-warning', id: 'delete' do
                     %span.glyphicon.glyphicon-exclamation-sign
                     Delete Proposal
-    .row
-      .col-md-8
-        .event-info.event-info-dense
-          %strong.event-title= event.name
-          - if event.start_date? && event.end_date?
-            %span.event-meta
-              %i.fa.fa-fw.fa-calendar
-              = event.date_range
-      .col-md-4.text-right.text-right-responsive
-        .event-info.event-info-dense
-          %span{:class => "event-meta event-status-badge event-status-#{event.status}"}
-            CFP 
-            = event.status
-          - if event.open?
-            %span.event-meta
-              CFP closes:
-              %strong= event.closes_at(:month_day_year)
-  .row
-    .col-md-12
-      %small
-        = proposal.session_format.try(:name)
-        - if proposal.track
-          \ –
-          = proposal.track.name
-  .row
-    .col-md-12.tags= proposal.tags
 
   .row
-    .col-md-4
-      .widget
-        .widget-header
-          %i.fa.fa-list-alt
-          %h3 Proposal Contents
-        .widget-content
-          = render partial: 'proposals/contents', locals: { proposal: proposal }
+    .col-md-8
+      = render partial: 'proposals/contents', locals: { proposal: proposal }
 
-    .col-md-4
-      .widget
-        .widget-header
-          %i.fa.fa-comment-o
-          %h3 Speakers
-        .widget-content
-          = render proposal.speakers
-          - if (proposal.has_speaker?(current_user))
-            %h3 Invited Speakers
-            - invitations.each do |invitation|
-              .clearfix
-                %ul.invitation
-                  %li
-                    = invitation.state_label
-                    = invitation.email
-                    .pull-right
-                      = link_to 'Resend',
-                        resend_invitation_path(invitation_slug: invitation.slug),
-                        method: :post,
-                        class: 'btn btn-xs btn-primary',
-                        disabled: !invitation.pending?
-                      = link_to 'Remove',
-                        invitation_path(invitation_slug: invitation.slug),
-                        method: :delete,
-                        class: 'btn btn-xs btn-danger',
-                        disabled: !invitation.pending?,
-                        data: {confirm: 'Are you sure you want to remove this invitation?'}
-            .new-speaker-invite
-              %p You may invite other speakers to your proposal.
-              .button.btn.btn-success.speaker-invite-button Invite a Speaker
-              .speaker-invite-form
-                = form_tag invitations_path(proposal_uuid: proposal.uuid), class: 'form-horizontal speaker' do
-                  %h3 Invite a Speaker
-                  .input-group{role: "group", "aria-label" => "Enter an Email to Invite a Speaker"}
-                    = email_field_tag :email, '', placeholder: "Enter an email address.", class: 'form-control'
-                    %span.input-group-btn
-                      %button.btn.btn-success(type="submit")
-                        %span.glyphicon.glyphicon-envelope
-                        Invite
+      .proposal-section
+        %h3 Speaker Information
+        = render proposal.speakers
+        - if (proposal.has_speaker?(current_user))
+          %h4.control-label Invited Speakers
+          - invitations.each do |invitation|
+            .clearfix
+              %ul.invitation
+                %li
+                  = invitation.state_label
+                  = invitation.email
+                  .pull-right
+                    = link_to 'Resend',
+                      resend_invitation_path(invitation_slug: invitation.slug),
+                      method: :post,
+                      class: 'btn btn-xs btn-primary',
+                      disabled: !invitation.pending?
+                    = link_to 'Remove',
+                      invitation_path(invitation_slug: invitation.slug),
+                      method: :delete,
+                      class: 'btn btn-xs btn-danger',
+                      disabled: !invitation.pending?,
+                      data: {confirm: 'Are you sure you want to remove this invitation?'}
+          .new-speaker-invite
+            %p You may invite other speakers to your proposal.
+            .button.btn.btn-success.speaker-invite-button Invite a Speaker
+            .speaker-invite-form
+              = form_tag invitations_path(proposal_uuid: proposal.uuid), class: 'form-horizontal speaker' do
+                %h3 Invite a Speaker
+                .input-group{role: "group", "aria-label" => "Enter an Email to Invite a Speaker"}
+                  = email_field_tag :email, '', placeholder: "Enter an email address.", class: 'form-control'
+                  %span.input-group-btn
+                    %button.btn.btn-success(type="submit")
+                      %span.glyphicon.glyphicon-envelope
+                      Invite
+
     .col-md-4
       .widget
         .widget-header

--- a/app/views/proposals/show.html.haml
+++ b/app/views/proposals/show.html.haml
@@ -23,6 +23,7 @@
       .col-md-8
         %h1
           = proposal.title
+          = proposal.public_state(small: true)
       .col-md-4
         - if proposal.has_speaker?(current_user)
           .toolbox.pull-right
@@ -80,14 +81,6 @@
 
     .col-md-4
       .widget.widget-card
-        .widget-header
-          %i.fa.fa-sticky-note-o
-          %h3 Reviewer Activity
-        .widget-content
-          %p.count
-            = pluralize(proposal.ratings.count, 'review')
-            = proposal.public_state
-      .widget
         .widget-header
           %i.fa.fa-comments
           %h3= pluralize(proposal.public_comments.count, 'comment')

--- a/app/views/speakers/_fields.html.haml
+++ b/app/views/speakers/_fields.html.haml
@@ -1,11 +1,10 @@
-%hr/
-.speaker.clearfix
-  %h3 Your Information
+%fieldset
+  %legend Your Information
   = f.simple_fields_for :speakers, f.object.speakers do |speaker_fields|
     - speaker = speaker_fields.object.decorate
     = speaker_fields.hidden_field :user_id, value: speaker.user_id
 
-    %p.help-block This information is <strong>not visible</strong> during the review process. Name and bio will be used publicly in the program if this proposal is selected.
+    %p This information is <strong>not visible</strong> during the review process. Name and bio will be used publicly in the program if this proposal is selected.
 
     = speaker_fields.input :name, disabled: true, tooltip: ["right", "Edit your profile to update"]
 

--- a/spec/features/proposal_spec.rb
+++ b/spec/features/proposal_spec.rb
@@ -133,7 +133,7 @@ feature "Proposals" do
     end
 
     it "does not show the speaker's name" do
-      within(:css, 'div.speaker-comment') do
+      within(:css, '.speaker-comment') do
         expect(page).not_to have_text(user.name)
       end
     end


### PR DESCRIPTION
This PR addresses card 96 - Updating speaker proposal pages (show/edit/new) with a consistent layout.
### Changes introduced:
- Moved event info bar to sit just below main nav
- Moved preview panel to a tab
- Added legends/headings to all fieldsets
- Moved tags field to just below abstract
- Updated comment styles
- Removed reviewer activity (no action to be taken, no particularly useful info  being shown to user)
### This PR does not address:
- tooltips
- label styles
- My Proposals layout
### Screenshots:

![new](https://cloud.githubusercontent.com/assets/522911/16930583/eac4142a-4d0a-11e6-8bc9-dd9ce37b1f01.png)

![show](https://cloud.githubusercontent.com/assets/522911/16931915/5ef66a22-4d11-11e6-9c9f-1bf0981bdce7.png)

![edit](https://cloud.githubusercontent.com/assets/522911/16930595/f1f60c80-4d0a-11e6-8abb-6353ef5cb652.png)

@mghaught
