### PR TITLE
#95 Update guidelines page

### DIFF
--- a/app/assets/stylesheets/modules/_events.scss
+++ b/app/assets/stylesheets/modules/_events.scss
@@ -74,6 +74,11 @@
     padding-right: 80px;
   }
 
+  .event-callout {
+    font-size: $font-size-large;
+    font-weight: bold;
+  }
+
   .event-meta {
     margin-top: $padding-large-vertical / 2;
     margin-left: 0;
@@ -83,24 +88,6 @@
     position: absolute;
     right: $padding-large-vertical / 2;
     top: $padding-large-vertical / 2;
-  }
-}
-
-// Builds on Bootstrap panels
-.event-info-panel {
-  & > .panel-heading {
-    font-size: $font-size-large;
-    text-transform: uppercase;
-  }
-
-  .event-label {
-    color: $gray;
-    font-weight: normal;
-  }
-
-  .event-callout {
-    font-size: $font-size-large;
-    margin-bottom: $padding-large-vertical * 2;
   }
 }
 

--- a/app/assets/stylesheets/modules/_events.scss
+++ b/app/assets/stylesheets/modules/_events.scss
@@ -51,6 +51,12 @@
   .event-meta {
     margin-left: $padding-base-horizontal;
     color: $gray;
+
+    // display meta info on separate lines for xs screens
+    @media (max-width: $screen-xs-max) {
+      margin-left: 0;
+      display: block;
+    } 
   }
 }
 

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -1,3 +1,21 @@
+.event-info-bar
+  .row
+    .col-md-8
+      .event-info.event-info-dense
+        %strong.event-title= event.name
+        - if event.start_date? && event.end_date?
+          %span.event-meta
+            %i.fa.fa-fw.fa-calendar
+            = event.date_range
+        - if event.url?
+          %span.event-meta
+            %i.fa.fa-fw.fa-external-link-square
+            = link_to(event.url, event.url, target: '_blank')
+        - if event.contact_email?
+          %span.event-meta
+            %i.fa.fa-fw.fa-envelope
+            = mail_to(event.contact_email)
+
 .row
   .col-md-12
     .page-header
@@ -7,17 +25,6 @@
 
 .row.margin-top
   .col-md-8
-    .event-info.event-info-block
-      %strong.event-title= event.name  
-      - if event.start_date? && event.end_date?
-        .event-meta
-          %i.fa.fa-fw.fa-calendar
-          = event.date_range
-      - if event.url?
-        %span.event-meta= link_to event.url
-      - if event.contact_email?
-        %span.event-meta= mail_to(event.contact_email)
-
     .markdown
       - if event.closed?
         Closed on

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -24,14 +24,7 @@
         Call for Proposals
 
 .row.margin-top
-  .col-md-8
-    .markdown
-      - if event.closed?
-        Closed on
-        %strong= event.closes_at(:long_with_zone)
-      = markdown(event.guidelines)
-
-  .col-md-4
+  .col-md-4.col-md-push-8
 
     - if event.open?
       .panel.panel-success.event-info.event-info-panel
@@ -68,3 +61,10 @@
         %h2 CFP Stats
         = pluralize(event.proposals.count, 'proposal')
         = event.line_chart
+
+  .col-md-8.col-md-pull-4
+    .markdown
+      - if event.closed?
+        Closed on
+        %strong= event.closes_at(:long_with_zone)
+      = markdown(event.guidelines)

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -1,7 +1,6 @@
 .row
   .col-md-12
     .page-header
-      .share.pull-right= event.tweet_button
       %h1
         = event.name 
         Call for Proposals

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -27,22 +27,22 @@
   .col-md-4.col-md-push-8
 
     - if event.open?
-      .panel.panel-success.event-info.event-info-panel
-        .panel-heading
-          CFP
-          = event.status
-        .panel-body
-          - if event.closes_at?
-            %dl
-              %dt.event-label
-                CFP closes: 
-              %dd.event-callout
-                = event.closes_at(:long_with_zone)
-              %dd
-                %strong= time_ago_in_words(event.closes_at)
-                left to submit your proposal
-          %div
-            = link_to 'Submit a proposal', new_event_proposal_path, class: 'btn btn-primary'
+      .event-info.event-info-block.callout
+        .call-header
+          .label.label-success.label-large.inline-block
+            CFP
+            = event.status
+        - if event.closes_at?
+          %dl.margin-top
+            %dt.event-label
+              CFP closes: 
+            %dd.event-callout
+              = event.closes_at(:long_with_zone)
+            %dd.margin-top
+              %strong= time_ago_in_words(event.closes_at)
+              left to submit your proposal
+        %div
+          = link_to 'Submit a proposal', new_event_proposal_path, class: 'btn btn-primary'
     - else
       .panel.panel-default
         .panel-heading

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -21,7 +21,7 @@
     .page-header
       %h1
         = event.name 
-        Call for Proposals
+        CFP
 
 .row.margin-top
   .col-md-4.col-md-push-8

--- a/app/views/layouts/_navbar.html.haml
+++ b/app/views/layouts/_navbar.html.haml
@@ -6,7 +6,7 @@
         %span.icon-bar
         %span.icon-bar
       - if current_event && current_event.slug
-        = link_to current_event.name, event_path(current_event), class: 'navbar-brand'
+        = link_to "#{current_event.name} CFP", event_path(current_event), class: 'navbar-brand'
       - else
         = link_to "#{Rails.application.class.parent_name}", events_path, class: 'navbar-brand'
 

--- a/spec/features/current_event_user_flow_spec.rb
+++ b/spec/features/current_event_user_flow_spec.rb
@@ -29,8 +29,8 @@ feature "A user sees correct information for the current event and their role" d
     end
 
     within ".page-header" do
-      expect(page).to have_content("#{event_1.name} Call for Proposals")
-      expect(page).to_not have_content("#{event_2.name} Call for Proposals")
+      expect(page).to have_content("#{event_1.name} CFP")
+      expect(page).to_not have_content("#{event_2.name} CFP")
     end
 
     speaker = create(:speaker, event: event_1, user: normal_user)


### PR DESCRIPTION
This PR makes some adjustments to the layout of the Event CFP/Guidelines page.
### Changes:
- Move event info to a bar underneath nav (similar to proposal pages)
- Restyle CFP info using the callout styles instead of panel styles
- Ensure that CFP info displays above guidelines on smaller screens
- Rename navbar logo to "[Event name] CFP"
### Screenshots:

![95-1](https://cloud.githubusercontent.com/assets/522911/17151030/ddbbd2dc-533f-11e6-8fe5-d45ec8a6ece2.png)

![95-2](https://cloud.githubusercontent.com/assets/522911/17151036/e08996b6-533f-11e6-9760-3bbbda95ab90.png)

@mghaught @gitcow 
