### PR TITLE
#113 Submitting a proposal

### DIFF
--- a/app/assets/stylesheets/base/_layout.scss
+++ b/app/assets/stylesheets/base/_layout.scss
@@ -17,13 +17,9 @@ body {
     margin-bottom: 0;
   }
 
-  // force page-header actions to sit bottom-flush with h1 for now
-  // until a page-header refactor using flexbox or display: table
-  .toolbox {
-    margin-top: 28px;
-  }
-
   .label {
+    display: inline-block;
+    margin-bottom: $padding-base-vertical;
     vertical-align: middle;
   }
 }

--- a/app/assets/stylesheets/modules/_forms.scss
+++ b/app/assets/stylesheets/modules/_forms.scss
@@ -52,3 +52,10 @@ span[title="required"] {
 .cancel-form {
   margin-right: .5em;
 }
+
+// Use a legend as the heading for major sections in a form.
+// Can also use the .fieldset-legend class to form heading styles
+// e.g., the show page for proposal
+.fieldset-legend {
+  @extend legend;
+}

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -54,7 +54,7 @@ class ProposalsController < ApplicationController
     if @proposal.save
       current_user.update_bio
       flash[:info] = setup_flash_message
-      redirect_to event_event_proposals_url(slug: @event.slug, uuid: @proposal)
+      redirect_to event_proposal_url(event_slug: @event.slug, uuid: @proposal)
     else
       flash[:danger] = 'There was a problem saving your proposal; please review the form for issues and try again.'
       render :new

--- a/app/decorators/proposal_decorator.rb
+++ b/app/decorators/proposal_decorator.rb
@@ -111,17 +111,17 @@ class ProposalDecorator < ApplicationDecorator
   end
 
   def title_input(form)
-    form.input :title, placeholder: 'Title of the talk',
+    form.input :title,
     maxlength: :lookup, input_html: { class: 'watched js-maxlength-alert' },
     hint: "Please limit your title to 60 characters or less."
   end
 
   def speaker_input(form)
-    form.input :speaker, placeholder: 'Speaker Name'
+    form.input :speaker
   end
 
   def abstract_input(form, tooltip = "Proposal Abstract")
-    form.input :abstract, placeholder: 'What is your talk about?',
+    form.input :abstract,
       maxlength: 605, input_html: { class: 'watched js-maxlength-alert', rows: 5 },
       hint: 'Provide a concise description for the program limited to 600 characters or less.', tooltip: tooltip
   end

--- a/app/decorators/proposal_decorator.rb
+++ b/app/decorators/proposal_decorator.rb
@@ -113,7 +113,7 @@ class ProposalDecorator < ApplicationDecorator
   def title_input(form)
     form.input :title,
     maxlength: :lookup, input_html: { class: 'watched js-maxlength-alert' },
-    hint: "Please limit your title to 60 characters or less."
+    hint: "Publicly viewable title. Ideally catchy, interesting, essence of the talk. Limited to 60 characters."
   end
 
   def speaker_input(form)
@@ -123,7 +123,7 @@ class ProposalDecorator < ApplicationDecorator
   def abstract_input(form, tooltip = "Proposal Abstract")
     form.input :abstract,
       maxlength: 605, input_html: { class: 'watched js-maxlength-alert', rows: 5 },
-      hint: 'Provide a concise description for the program limited to 600 characters or less.', tooltip: tooltip
+      hint: 'A concise, engaging description for the public program. Limited to 600 characters.', tooltip: tooltip
   end
 
   private

--- a/app/views/proposals/_contents.html.haml
+++ b/app/views/proposals/_contents.html.haml
@@ -2,20 +2,24 @@
   %h3.control-label Title
   .markdown{ data: { 'field-id' => 'proposal_title' } }
     = proposal.title
+  %p.help-block Publicly viewable title. Ideally catchy, interesting, essence of the talk. Limited to 60 characters.
 
 .proposal-section
   %h3.control-label Session Format
   = proposal.session_format.try(:name)
+  %p.help-block The format your proposal will follow.
 
 - if proposal.track
   .proposal-section
     %h3.control-label Track
     = proposal.track.name
+    %p.help-block Optional: suggest a specific track to be considered for.
 
 .proposal-section
   %h3.control-label Abstract
   .markdown{ data: { 'field-id' => 'proposal_abstract' } }
     = proposal.abstract_markdown
+  %p.help-block A concise, engaging description for the public program. Limited to 600 characters.
 
 -if proposal.event.public_tags?
   .proposal-section
@@ -28,11 +32,13 @@
   %h3.control-label Details
   .markdown{ data: { 'field-id' => 'proposal_details' } }
     = proposal.details
+  %p.help-block Include any pertinent details such as outlines, outcomes or intended audience
 
 .proposal-section
   %h3.control-label Pitch
   .markdown{ data: { 'field-id' => 'proposal_pitch' } }
     =proposal.pitch
+  %p.help-block Explain why this talk should be considered and what makes you qualified to speak on the topic.
 
 - if proposal.custom_fields.any?
   - proposal.proposal_data[:custom_fields].select do |key,value|

--- a/app/views/proposals/_contents.html.haml
+++ b/app/views/proposals/_contents.html.haml
@@ -1,41 +1,43 @@
 .proposal-section
-  %h3 Title
+  %h3.control-label Title
   .markdown{ data: { 'field-id' => 'proposal_title' } }
     = proposal.title
 
 .proposal-section
-  %h3 Session Format
+  %h3.control-label Session Format
   = proposal.session_format.try(:name)
 
 - if proposal.track
   .proposal-section
-    %h3 Track
+    %h3.control-label Track
     = proposal.track.name
 
 .proposal-section
-  %h3 Abstract
+  %h3.control-label Abstract
   .markdown{ data: { 'field-id' => 'proposal_abstract' } }
     = proposal.abstract_markdown
 
 -if proposal.event.public_tags?
   .proposal-section
-    %h3 Tags
+    %h3.control-label Tags
     %p= proposal.tags
 
-.proposal-section
-  %h3 Details
+%h2.fieldset-legend For Review Committee
+
+.proposal-section  
+  %h3.control-label Details
   .markdown{ data: { 'field-id' => 'proposal_details' } }
     = proposal.details
 
 .proposal-section
-  %h3 Pitch
+  %h3.control-label Pitch
   .markdown{ data: { 'field-id' => 'proposal_pitch' } }
     =proposal.pitch
 
 - if proposal.custom_fields.any?
   - proposal.proposal_data[:custom_fields].select do |key,value|
     .proposal-section
-      %h3= key.capitalize
+      %h3.control-label= key.capitalize
       %div
       = value.capitalize
       %div

--- a/app/views/proposals/_form.html.haml
+++ b/app/views/proposals/_form.html.haml
@@ -22,7 +22,7 @@
         {}, {class: 'multiselect proposal-tags', multiple: true }
 
 %fieldset
-  %legend For Review Committee
+  %legend.fieldset-legend For Review Committee
   %p
     This content will <strong> only</strong> be visible to the review committee.
 

--- a/app/views/proposals/_form.html.haml
+++ b/app/views/proposals/_form.html.haml
@@ -1,6 +1,4 @@
-
-%fieldset
-  %legend Proposal Details
+%fieldset.margin-top
   = proposal.title_input(f)
 
   - opts_session_formats = event.session_formats.publicly_viewable.map {|st| [st.name, st.id]}

--- a/app/views/proposals/_form.html.haml
+++ b/app/views/proposals/_form.html.haml
@@ -27,11 +27,9 @@
     This content will <strong> only</strong> be visible to the review committee.
 
   = f.input :details, input_html: { class: 'watched', rows: 5 },
-    placeholder: 'Explain the theme and flow of your talk. What are the intended audience takeaways?',
     hint: 'Include any pertinent details such as outlines, outcomes or intended audience.', tooltip: ["right", details_tooltip]
 
-  = f.input :pitch, input_html: { class: 'watched', rows: 5 },
-    placeholder: 'Why is this talk pertinent? What is your involvement in the topic?',
+  = f.input :pitch, input_html: { class: 'watched', rows: 5 }, 
     hint: 'Explain why this talk should be considered and what makes you qualified to speak on the topic.', tooltip: ["right", pitch_tooltip]
 
 - if event.custom_fields.any?

--- a/app/views/proposals/_form.html.haml
+++ b/app/views/proposals/_form.html.haml
@@ -40,7 +40,11 @@
 
 = render partial: 'speakers/fields', locals: { f: f, event: event }
 
-.form-submit.clearfix
-  %button.pull-right.btn.btn-primary.btn-lg{type: "submit"} Save
+.form-submit.clearfix.text-right
+  - if proposal.persisted?
+    = link_to "Cancel", event_proposal_path(event_slug: event.slug, uuid: proposal), {class: "btn btn-default btn-lg"}
+  - else
+    = link_to "Cancel", event_path(event.slug), {class: "btn btn-default btn-lg"}
+  %button.btn.btn-primary.btn-lg{type: "submit"} Save
 
 

--- a/app/views/proposals/_form.html.haml
+++ b/app/views/proposals/_form.html.haml
@@ -4,13 +4,13 @@
   - opts_session_formats = event.session_formats.publicly_viewable.map {|st| [st.name, st.id]}
 
   - if opts_session_formats.length > 1
-    = f.association :session_format, collection: opts_session_formats, include_blank: 'None selected', required: true, input_html: {class: 'dropdown'}, hint: "Session Format Hint", tooltip: ["right", session_format_tooltip]
+    = f.association :session_format, collection: opts_session_formats, include_blank: 'None selected', required: true, input_html: {class: 'dropdown'}, hint: "The format your proposal will follow.", tooltip: ["right", session_format_tooltip]
   - else
-    = f.association :session_format, collection: opts_session_formats, include_blank: false, input_html: {readonly: "readonly"}, hint: "Session Format Hint", tooltip: ["right", "Only One Session Format for #{event.name}"]
+    = f.association :session_format, collection: opts_session_formats, include_blank: false, input_html: {readonly: "readonly"}, hint: "The format your proposal will follow.", tooltip: ["right", "Only One Session Format for #{event.name}"]
 
   - opts_tracks = event.tracks.map {|t| [t.name, t.id]}
   -if opts_tracks.length > 0
-    = f.association :track, collection: opts_tracks, include_blank: 'None selected', input_html: {class: 'dropdown'}, hint: "Track Hint", tooltip: ["right", track_tooltip]
+    = f.association :track, collection: opts_tracks, include_blank: 'None selected', input_html: {class: 'dropdown'}, hint: "Optional: suggest a specific track to be considered for.", tooltip: ["right", track_tooltip]
 
   = proposal.abstract_input(f, abstract_tooltip)
 

--- a/app/views/proposals/edit.html.haml
+++ b/app/views/proposals/edit.html.haml
@@ -23,14 +23,13 @@
       %h1
         Edit
         %em #{proposal.title}
-        for #{event}
 
 .row
   .col-md-12
     .tabbable
       %ul.nav.nav-tabs
         %li.active
-          %a{"data-toggle" => "tab", :href => "#edit-proposal"} Edit proposal
+          %a{"data-toggle" => "tab", :href => "#edit-proposal"} Proposal Form
         %li
           %a{"data-toggle" => "tab", :href => "#preview"} Preview
       .tab-content

--- a/app/views/proposals/new.html.haml
+++ b/app/views/proposals/new.html.haml
@@ -20,14 +20,14 @@
 .page-header.page-header-slim
   .row
     .col-md-12
-      %h1 New Proposal for #{event}
+      %h1 Submit a Proposal
 
 .row
   .col-md-12
     .tabbable
       %ul.nav.nav-tabs
         %li.active
-          %a{"data-toggle" => "tab", :href => "#create-proposal"} Create proposal
+          %a{"data-toggle" => "tab", :href => "#create-proposal"} Proposal Form
         %li
           %a{"data-toggle" => "tab", :href => "#preview"} Preview
       .tab-content

--- a/app/views/proposals/show.html.haml
+++ b/app/views/proposals/show.html.haml
@@ -46,32 +46,36 @@
 
       .proposal-section
         %h3.fieldset-legend Speaker Information
-        = render proposal.speakers
-        - if (proposal.has_speaker?(current_user))
-          %h4.control-label Invited Speakers
-          - invitations.each do |invitation|
-            .clearfix
-              %ul.invitation
-                %li
-                  = invitation.state_label
-                  = invitation.email
-                  .pull-right
-                    = link_to 'Resend',
-                      resend_invitation_path(invitation_slug: invitation.slug),
-                      method: :post,
-                      class: 'btn btn-xs btn-primary',
-                      disabled: !invitation.pending?
-                    = link_to 'Remove',
-                      invitation_path(invitation_slug: invitation.slug),
-                      method: :delete,
-                      class: 'btn btn-xs btn-danger',
-                      disabled: !invitation.pending?,
-                      data: {confirm: 'Are you sure you want to remove this invitation?'}
-          .new-speaker-invite
-            %p
-              You may invite other speakers to your proposal.
+        .row
+          .col-md-8
+            = render proposal.speakers
+          .col-md-4
+            .new-speaker-invite
               %button.button.btn.btn-success.btn-xs.speaker-invite-button 
                 Invite a Speaker
+              %p.help-block You may invite other speakers to your proposal.
+        .row
+          .col-md-12
+            - if (proposal.has_speaker?(current_user) && invitations.any?)
+              %h4.control-label Invited Speakers
+              - invitations.each do |invitation|
+                .clearfix
+                  %ul.invitation
+                    %li
+                      = invitation.state_label
+                      = invitation.email
+                      .pull-right
+                        = link_to 'Resend',
+                          resend_invitation_path(invitation_slug: invitation.slug),
+                          method: :post,
+                          class: 'btn btn-xs btn-primary',
+                          disabled: !invitation.pending?
+                        = link_to 'Remove',
+                          invitation_path(invitation_slug: invitation.slug),
+                          method: :delete,
+                          class: 'btn btn-xs btn-danger',
+                          disabled: !invitation.pending?,
+                          data: {confirm: 'Are you sure you want to remove this invitation?'}
             .speaker-invite-form
               = form_tag invitations_path(proposal_uuid: proposal.uuid), class: 'speaker' do
                 .widget.widget-card

--- a/app/views/proposals/show.html.haml
+++ b/app/views/proposals/show.html.haml
@@ -23,10 +23,11 @@
       .col-md-8
         %h1
           = proposal.title
-          = proposal.public_state(small: true)
       .col-md-4
-        - if proposal.has_speaker?(current_user)
-          .toolbox.pull-right
+        .toolbox.pull-right
+          .clearfix.text-right
+            = proposal.public_state(small: true)
+          - if proposal.has_speaker?(current_user)
             .clearfix
               - unless proposal.withdrawn? || proposal.accepted? || proposal.confirmed?
                 = link_to edit_event_proposal_path(event_slug: event.slug, uuid: proposal), class: 'btn btn-primary' do

--- a/app/views/proposals/show.html.haml
+++ b/app/views/proposals/show.html.haml
@@ -44,7 +44,7 @@
       = render partial: 'proposals/contents', locals: { proposal: proposal }
 
       .proposal-section
-        %h3 Speaker Information
+        %h3.fieldset-legend Speaker Information
         = render proposal.speakers
         - if (proposal.has_speaker?(current_user))
           %h4.control-label Invited Speakers

--- a/app/views/proposals/show.html.haml
+++ b/app/views/proposals/show.html.haml
@@ -91,3 +91,5 @@
         .widget-content
           = render partial: 'proposals/comments',
             locals: { proposal: proposal, comments: proposal.public_comments }
+      %p.help-block Have questions or feeback on your proposal? The comments allow you to anonymously converse with the review committee.
+

--- a/app/views/speakers/_fields.html.haml
+++ b/app/views/speakers/_fields.html.haml
@@ -7,4 +7,4 @@
 
     = speaker_fields.input :name, disabled: true, tooltip: ["right", "Edit your profile to update"]
 
-    = speaker_fields.input :bio, maxlength: :lookup, placeholder: 'Bio for the event program.', input_html: { value: speaker.bio, rows: 4 }, hint: 'Your bio should be short, no longer than 500 characters. It\'s related to why you\'re speaking about this topic.', tooltip: bio_tooltip
+    = speaker_fields.input :bio, maxlength: :lookup, input_html: { value: speaker.bio, rows: 4 }, hint: 'Your bio should be short, no longer than 500 characters. It\'s related to why you\'re speaking about this topic.', tooltip: bio_tooltip

--- a/app/views/speakers/_fields.html.haml
+++ b/app/views/speakers/_fields.html.haml
@@ -1,5 +1,5 @@
 %fieldset
-  %legend Speaker Information
+  %legend.fieldset-legend Speaker Information
   = f.simple_fields_for :speakers, f.object.speakers do |speaker_fields|
     - speaker = speaker_fields.object.decorate
 

--- a/app/views/speakers/_fields.html.haml
+++ b/app/views/speakers/_fields.html.haml
@@ -1,5 +1,5 @@
 %fieldset
-  %legend Your Information
+  %legend Speaker Information
   = f.simple_fields_for :speakers, f.object.speakers do |speaker_fields|
     - speaker = speaker_fields.object.decorate
 

--- a/app/views/speakers/_speaker.html.haml
+++ b/app/views/speakers/_speaker.html.haml
@@ -1,7 +1,7 @@
 - withdraw = true if withdraw.nil?
 
 .speaker.clearfix
-  %strong= speaker.name_and_email
+  %strong= speaker.name
   = simple_format speaker.bio
 
   - if withdraw && speaker.proposal.speakers.count > 1


### PR DESCRIPTION
# WIP - View updates: proposal pages

This PR addresses card 113, based on Marty's notes about changes to the proposal view pages.
- Misc. text updates: page headers, form headings, hint text
- Removes placeholder text
- Adds cancel button that redirects to CFP page if creating new proposal and proposal show page if editing proposal
- Redirects user to proposal show page after saving new proposal 
