### PR TITLE
#109 reviewer pages

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -34,6 +34,7 @@
 @import "base/base";
 @import "base/layout";
 @import "base/helper_classes";
+@import "base/typography";
 
 // page specific styles
 // @import "pages/*";

--- a/app/assets/stylesheets/base/_helper_classes.scss
+++ b/app/assets/stylesheets/base/_helper_classes.scss
@@ -16,7 +16,7 @@
 .inline-block {
   display: inline-block;
 }
-.white-text { color: $white; }
+
 .bg-gray-base { background-color: $gray-base; }
 .bg-gray-darker { background-color: $gray-darker; }
 .bg-gray-dark { background-color: $gray-dark; }
@@ -30,24 +30,3 @@
 .bg-brand-warning { background-color: $brand-warning; }
 .bg-brand-danger { background-color: $brand-danger; }
 .bg-brand-accent { background-color: $brand-accent; }
-
-.gray-base { color: $gray-base; }
-.gray-darker { color: $gray-darker; }
-.gray-dark { color: $gray-dark; }
-.gray { color: $gray }
-.gray-light { color: $gray-light; }
-.gray-lighter { color: $gray-lighter; }
-.brand-primary { color: $brand-primary; }
-.brand-success { color: $brand-success; }
-.brand-info { color: $brand-info; }
-.brand-info-alt { color: $brand-info-alt; }
-.brand-warning { color: $brand-warning; }
-.brand-danger { color: $brand-danger; }
-.brand-accent { color: $brand-accent; }
-
-.text-right-responsive,
-.text-center-responsive {
-  @media (max-width: 767px) {
-    text-align: left;
-  }
-}

--- a/app/assets/stylesheets/base/_layout.scss
+++ b/app/assets/stylesheets/base/_layout.scss
@@ -14,6 +14,7 @@ body {
   }
 
   h1 {
+    margin-top: 0;
     margin-bottom: 0;
   }
 
@@ -21,6 +22,10 @@ body {
     display: inline-block;
     margin-bottom: $padding-base-vertical;
     vertical-align: middle;
+  }
+
+  .meta-text {
+    margin-bottom: $padding-base-vertical;
   }
 }
 

--- a/app/assets/stylesheets/base/_typography.scss
+++ b/app/assets/stylesheets/base/_typography.scss
@@ -1,0 +1,37 @@
+// Text modules
+// Include any overrides to Bootstrap typography here
+.meta-text {
+  font-size: $font-size-small;
+  color: $gray;
+}
+
+.help-block {
+  color: darken($brand-success, 5%);
+  font-size: 0.9em;
+  font-style: italic;
+}
+
+// Misc helper classes
+.white-text { color: $white; }
+.gray-base { color: $gray-base; }
+.gray-darker { color: $gray-darker; }
+.gray-dark { color: $gray-dark; }
+.gray { color: $gray }
+.gray-light { color: $gray-light; }
+.gray-lighter { color: $gray-lighter; }
+.brand-primary { color: $brand-primary; }
+.brand-success { color: $brand-success; }
+.brand-info { color: $brand-info; }
+.brand-info-alt { color: $brand-info-alt; }
+.brand-warning { color: $brand-warning; }
+.brand-danger { color: $brand-danger; }
+.brand-accent { color: $brand-accent; }
+
+// Responsive text:
+// Reset to left-align on smaller screens
+.text-right-responsive,
+.text-center-responsive {
+  @media (max-width: 767px) {
+    text-align: left;
+  }
+}

--- a/app/assets/stylesheets/modules/_forms.scss
+++ b/app/assets/stylesheets/modules/_forms.scss
@@ -5,11 +5,6 @@
   margin-bottom: 10px;
   padding-bottom: 5px;
 }
-.help-block {
-  color: darken($brand-success, 5%);
-  font-size: 0.9em;
-  font-style: italic;
-}
 
 .field_with_errors {
   .form-control {

--- a/app/assets/stylesheets/modules/_proposal.scss
+++ b/app/assets/stylesheets/modules/_proposal.scss
@@ -173,4 +173,9 @@ div.col-md-4 {
       margin-right: 0;
     }
   }
+
+  .page-header & {
+    padding-top: $padding-large-vertical;
+    padding-bottom: 0;
+  }
 }

--- a/app/assets/stylesheets/modules/_widgets.scss
+++ b/app/assets/stylesheets/modules/_widgets.scss
@@ -145,4 +145,10 @@
       line-height: 1;
     }
   }
+
+  &.widget-card-alt,
+  &.widget-card-alt .widget-header,
+  &.widget-card-alt .widget-content {
+    background: lighten($brand-info, 45%);
+  }
 }

--- a/app/views/proposals/_reviewer_contents.html.haml
+++ b/app/views/proposals/_reviewer_contents.html.haml
@@ -1,0 +1,32 @@
+.proposal-section
+  %h3.control-label Abstract
+  .markdown{ data: { 'field-id' => 'proposal_abstract' } }
+    = proposal.abstract_markdown
+  %p.help-block A concise, engaging description for the public program. Limited to 600 characters.
+
+-if proposal.event.public_tags?
+  .proposal-section
+    %h3.control-label Tags
+    %p= proposal.tags
+
+%h2.fieldset-legend For Review Committee
+
+.proposal-section  
+  %h3.control-label Details
+  .markdown{ data: { 'field-id' => 'proposal_details' } }
+    = proposal.details
+  %p.help-block Include any pertinent details such as outlines, outcomes or intended audience
+
+.proposal-section
+  %h3.control-label Pitch
+  .markdown{ data: { 'field-id' => 'proposal_pitch' } }
+    =proposal.pitch
+  %p.help-block Explain why this talk should be considered and what makes you qualified to speak on the topic.
+
+- if proposal.custom_fields.any?
+  - proposal.proposal_data[:custom_fields].select do |key,value|
+    .proposal-section
+      %h3.control-label= key.capitalize
+      %div
+      = value.capitalize
+      %div

--- a/app/views/proposals/show.html.haml
+++ b/app/views/proposals/show.html.haml
@@ -21,6 +21,7 @@
   .page-header.page-header-slim
     .row
       .col-md-8
+        .meta-text= proposal.updated_in_words
         %h1
           = proposal.title
       .col-md-4

--- a/app/views/shared/proposals/_rating_form.html.haml
+++ b/app/views/shared/proposals/_rating_form.html.haml
@@ -8,9 +8,11 @@
           data: {toggle: 'tooltip', placement: 'right', trigger: 'hover'}, title: rating_tooltip }
 
   - unless rating.new_record?
-    %dl.dl-horizontal.ratings_list
-      %dt.text-success Average rating:
-      %dd.text-success= number_with_precision(proposal.average_rating, precision: 1)
+    %dl.dl-horizontal.ratings_list.margin-top
+      %dt.text-success 
+        %strong Average rating:
+      %dd.text-success
+        %strong= number_with_precision(proposal.average_rating, precision: 1)
       - proposal.ratings.each do |rating|
         %dt= "#{rating.user.name}:"
         %dd= rating.score

--- a/app/views/shared/proposals/_tags_form.html.haml
+++ b/app/views/shared/proposals/_tags_form.html.haml
@@ -8,4 +8,5 @@
           = f.select :review_tags,
             options_for_select(event.review_tags, proposal.object.review_tags),
             {}, { class: 'multiselect review-tags', multiple: true }
-          %button.pull-right.btn.btn-success{:type => "submit"} Update
+      .form-group
+        %button.btn.btn-success.pull-right{:type => "submit"} Update

--- a/app/views/staff/proposal_reviews/show.html.haml
+++ b/app/views/staff/proposal_reviews/show.html.haml
@@ -21,9 +21,9 @@
   .page-header.page-header-slim
     .row
       .col-md-8
+        .meta-text= proposal.updated_in_words
         %h1
           = proposal.title
-        .proposal-meta-item= proposal.updated_in_words
           
       .col-md-4
         .text-right
@@ -34,11 +34,6 @@
               &laquo; Return to Proposals
             = link_to "Next Proposal", event_staff_proposal_path(uuid: "PLACEHOLDER"), class: "next-proposal btn btn-primary", data: {"proposal-uuid" => proposal.uuid }
   
-  .proposal-info-bar
-    .proposal-meta
-      .proposal-meta-item= proposal.created_in_words
-      .proposal-meta-item= proposal.updated_in_words
-
   .row
     .col-md-4
       = render partial: 'proposals/contents', locals: { proposal: proposal }

--- a/app/views/staff/proposal_reviews/show.html.haml
+++ b/app/views/staff/proposal_reviews/show.html.haml
@@ -33,10 +33,22 @@
             = link_to(event_staff_proposals_path, class: "btn btn-primary") do
               &laquo; Return to Proposals
             = link_to "Next Proposal", event_staff_proposal_path(uuid: "PLACEHOLDER"), class: "next-proposal btn btn-primary", data: {"proposal-uuid" => proposal.uuid }
-  
+    .proposal-info-bar
+      .proposal-meta.proposal-description
+        .proposal-meta-item
+          %strong #{ 'Speaker'.pluralize(proposal.speakers.count) }:
+          %span= proposal.speakers.collect { |speaker| speaker.name }.join(', ')
+        .proposal-meta-item
+          %strong Format:
+          %span #{proposal.session_format.name}
+        
+        - if proposal.track
+          .proposal-meta-item
+            %strong Track:
+            %span #{proposal.track.name}
   .row
     .col-md-4
-      = render partial: 'proposals/contents', locals: { proposal: proposal }
+      = render partial: 'proposals/reviewer_contents', locals: { proposal: proposal }
     .col-md-4
       .widget.widget-card.flush-top
         .widget-header

--- a/app/views/staff/proposal_reviews/show.html.haml
+++ b/app/views/staff/proposal_reviews/show.html.haml
@@ -23,35 +23,35 @@
       .col-md-8
         %h1
           = proposal.title
-          = proposal.public_state(small: true)
+        .proposal-meta-item= proposal.updated_in_words
+          
       .col-md-4
-        .btn-nav.pull-right
-          = link_to(event_staff_proposals_path, class: "btn btn-primary") do
-            &laquo; Return to Proposals
-          = link_to "Next Proposal", event_staff_proposal_path(uuid: "PLACEHOLDER"), class: "next-proposal btn btn-primary", data: {"proposal-uuid" => proposal.uuid }
-    .row
-      .col-md-4
-        %span.label.label-info= proposal.created_in_words
-
-        %span.label.label-info= proposal.updated_in_words
-        %br/
-        .tags= proposal.tags
+        .text-right
+          %div
+            = proposal.public_state(small: true)
+          %div
+            = link_to(event_staff_proposals_path, class: "btn btn-primary") do
+              &laquo; Return to Proposals
+            = link_to "Next Proposal", event_staff_proposal_path(uuid: "PLACEHOLDER"), class: "next-proposal btn btn-primary", data: {"proposal-uuid" => proposal.uuid }
+  
+  .proposal-info-bar
+    .proposal-meta
+      .proposal-meta-item= proposal.created_in_words
+      .proposal-meta-item= proposal.updated_in_words
 
   .row
     .col-md-4
       = render partial: 'proposals/contents', locals: { proposal: proposal }
-
     .col-md-4
-      .widget.widget-card
+      .widget.widget-card.flush-top
         .widget-header
           %i.fa.fa-comments
           %h3= pluralize(proposal.public_comments.count, 'public comment')
         .widget-content
           = render partial: 'proposals/comments',
             locals: { proposal: proposal, comments: proposal.public_comments }
-
     .col-md-4
-      .widget.widget-card
+      .widget.widget-card.widget-card-alt.flush-top
         .widget-header
           %h3 Review
         .widget-content


### PR DESCRIPTION
This PR addresses card 109, update reviewer pages to look similar to speaker pages.
### Changes:
- Move ratings form underneath proposal content
- Display ratings guide alongside the form instead of in a tooltip
- Display last updated meta text above proposal title
### Notes/comments:
- Would be nice to have tags not be in a select box (for both speaker and reviewers). When multiple tags are selected, the select box becomes really awkward. Maybe just a list of checkboxes?
### Screenshots:

**Reviewer view:**

![103-1](https://cloud.githubusercontent.com/assets/522911/17254778/39a57530-5584-11e6-8673-86413f4414c9.png)

**Speaker view:**

![103-2](https://cloud.githubusercontent.com/assets/522911/17254709/f494312a-5583-11e6-8769-a46235fcce7c.png)

@mghaught @gitcow 
