### PR TITLE
#117 comment notification logic

### DIFF
--- a/app/controllers/staff/proposals_controller.rb
+++ b/app/controllers/staff/proposals_controller.rb
@@ -7,7 +7,7 @@ class Staff::ProposalsController < Staff::ApplicationController
   def finalize
     @proposal.finalize
     send_state_mail(@proposal.state)
-    redirect_to event_staff_proposal_url(@proposal.event, @proposal)
+    redirect_to event_staff_proposal_path(@proposal.event, @proposal)
   end
 
   def update_state
@@ -45,7 +45,7 @@ class Staff::ProposalsController < Staff::ApplicationController
       end
     end
 
-    current_user.notifications.mark_as_read_for_proposal(event_staff_proposal_url(@event, @proposal))
+    current_user.notifications.mark_as_read_for_proposal(event_staff_proposal_path(@event, @proposal))
     render locals: {
              speakers: @proposal.speakers.decorate,
              other_proposals: Staff::ProposalsDecorator.decorate(other_proposals),
@@ -59,7 +59,7 @@ class Staff::ProposalsController < Staff::ApplicationController
   def update
     if @proposal.update_without_touching_updated_by_speaker_at(proposal_params)
       flash[:info] = 'Proposal Updated'
-      redirect_to event_staff_proposal_url(@event, @proposal)
+      redirect_to event_staff_proposal_path(@event, @proposal)
     else
       flash[:danger] = 'There was a problem saving your proposal; please review the form for issues and try again.'
       render :edit

--- a/app/controllers/staff/speakers_controller.rb
+++ b/app/controllers/staff/speakers_controller.rb
@@ -26,7 +26,7 @@ class Staff::SpeakersController < Staff::ApplicationController
     else
       flash[:danger] = "Could not find a user with this email address"
     end
-    redirect_to event_staff_proposal_url(event, @proposal)
+    redirect_to event_staff_proposal_path(event, @proposal)
   end
 
   #if user input (params), exist
@@ -54,7 +54,7 @@ class Staff::SpeakersController < Staff::ApplicationController
     @speaker.destroy
 
     flash[:info] = "You've deleted the speaker for this proposal"
-    redirect_to event_staff_proposal_url(uuid: proposal)
+    redirect_to event_staff_proposal_path(uuid: proposal)
   end
 
   def emails

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -1,13 +1,12 @@
 class UserDecorator < ApplicationDecorator
   delegate_all
 
-  def proposal_url(proposal)
+  def proposal_notification_path(proposal)
     event = proposal.event
-    if model.staff_for? event
-      h.event_staff_proposal_url(event, proposal)
+    if proposal.has_speaker?(object)
+      h.event_proposal_path(event, proposal)
     else
-      h.event_proposal_url(event, proposal)
+      h.event_staff_proposal_path(event, proposal)
     end
-
   end
 end

--- a/app/models/internal_comment.rb
+++ b/app/models/internal_comment.rb
@@ -5,8 +5,8 @@ class InternalComment < Comment
 
   # Generate notifications for InternalComment
 
-  # 2. If a a reviewer/organizer leaves a comment,
-  #  only the other reviewers of proposal get an in app notification.
+  # If a reviewer/organizer leaves a comment,
+  #  only the other reviewers of proposal get an in-app notification.
   def notify
     reviewers = proposal.reviewers.reject{|r| r.id == user_id }
     Notification.create_for(reviewers, proposal: proposal, message: "Internal comment on #{proposal.title}")

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -8,7 +8,7 @@ class Notification < ActiveRecord::Base
   def self.create_for(users, args = {})
     proposal = args.delete(:proposal)
     users.each do |user|
-      args[:target_path] = user.decorate.proposal_url(proposal) if proposal
+      args[:target_path] = user.decorate.proposal_notification_path(proposal) if proposal
       user.notifications.create(args)
     end
   end

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -67,13 +67,14 @@ class Proposal < ActiveRecord::Base
   # A user is considered a reviewer if they meet the following criteria
   # - They are an teammate for this event
   # AND
-  # - They have rated or made a public comment on this proposal, this means they are a 'reviewer'
+  # - They have rated or made a public comment on this proposal, and are not a speaker on this proposal
   def reviewers
     User.joins(:teammates,
                  'LEFT OUTER JOIN ratings AS r ON r.user_id = users.id',
                  'LEFT OUTER JOIN comments AS c ON c.user_id = users.id')
-      .where("teammates.event_id = ? AND (r.proposal_id = ? or (c.proposal_id = ? AND c.type = 'PublicComment'))",
-             event.id, id, id).uniq
+        .where("teammates.event_id = ? AND (r.proposal_id = ? or (c.proposal_id = ? AND c.type = 'PublicComment'))",
+               event.id, id, id)
+        .where.not(id: speakers.map(&:user_id)).uniq
   end
 
   # Return all proposals from speakers of this proposal. Does not include this proposal.

--- a/spec/decorators/user_decorator_spec.rb
+++ b/spec/decorators/user_decorator_spec.rb
@@ -2,20 +2,20 @@ require 'rails_helper'
 
 describe UserDecorator do
 
-  describe "#proposal_url" do
+  describe "#proposal_notification_path" do
 
-    it "returns the url for a speaker" do
+    it "returns the proposal path for a speaker" do
       speaker = create(:speaker)
       proposal = create(:proposal, speakers: [ speaker ])
-      expect(speaker.user.decorate.proposal_url(proposal)).to(
-        eq(h.event_proposal_url(proposal.event.slug, proposal)))
+      expect(speaker.user.decorate.proposal_notification_path(proposal)).to(
+        eq(h.event_proposal_path(proposal.event.slug, proposal)))
     end
 
-    it "returns the url for a reviewer" do
+    it "returns the proposal path for a reviewer" do
       reviewer = create(:user, :reviewer)
       proposal = create(:proposal)
-      expect(reviewer.decorate.proposal_url(proposal)).to(
-        eq(h.event_staff_proposal_url(proposal.event, proposal)))
+      expect(reviewer.decorate.proposal_notification_path(proposal)).to(
+        eq(h.event_staff_proposal_path(proposal.event, proposal)))
     end
   end
 end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -31,7 +31,7 @@ describe Notification do
       proposal = create(:proposal)
       Notification.create_for(users, proposal: proposal)
       users.each do |p|
-        expect(p.decorate.proposal_url(proposal)).to(
+        expect(p.decorate.proposal_notification_path(proposal)).to(
           eq(p.notifications.first.target_path))
       end
     end


### PR DESCRIPTION
- Ensure staff are notified when speaker-who-is-also-staff leaves public comment.
- Ensure speaker-who-is-also-staff isn't included in list of reviewers.
- Ensure comment notifications for speaker-who-is-also-staff have non-staff link.
