### PR TITLE
Scopes subnav to event dashboard pages

### DIFF
--- a/app/assets/stylesheets/modules/_navbar.scss
+++ b/app/assets/stylesheets/modules/_navbar.scss
@@ -14,7 +14,7 @@
 */
 
 .subnavbar {
-  margin: 0 0;
+  margin: 0 0 ;
   .subnavbar-inner {
     background: #fff;
     border-bottom: 1px solid $gray-light;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,6 +15,7 @@ class ApplicationController < ActionController::Base
   helper_method :organizer?
   helper_method :event_staff?
   helper_method :speaker_for_proposal?
+  helper_method :display_staff_subnav?
 
   before_action :current_event
 
@@ -121,5 +122,13 @@ class ApplicationController < ActionController::Base
 
   def set_title(title)
     @title = title[0..25] if title
+  end
+
+  def enable_staff_subnav
+    @display_staff_subnav = true
+  end
+
+  def display_staff_subnav?
+    @display_staff_subnav
   end
 end

--- a/app/controllers/staff/events_controller.rb
+++ b/app/controllers/staff/events_controller.rb
@@ -1,4 +1,5 @@
 class Staff::EventsController < Staff::ApplicationController
+  before_action :enable_staff_subnav
 
   def edit
   end

--- a/app/controllers/staff/teammates_controller.rb
+++ b/app/controllers/staff/teammates_controller.rb
@@ -1,6 +1,7 @@
 class Staff::TeammatesController < Staff::ApplicationController
   # what is this? review this line - probably junk
   skip_before_filter :require_proposal, only: [:update], if: proc {|c| current_user && current_user.reviewer? }
+  before_action :enable_staff_subnav
   respond_to :html, :json
 
   def index

--- a/app/views/layouts/_navbar.html.haml
+++ b/app/views/layouts/_navbar.html.haml
@@ -49,5 +49,4 @@
               %i.fa.fa-dashboard
               %span Dashboard
 
-- if params[:controller].include?("staff") && user_signed_in?
-  = render partial: "layouts/nav/staff_subnav"
+= render partial: "layouts/nav/staff_subnav" if display_staff_subnav?


### PR DESCRIPTION
Prior to this PR we rendered the staff subnav on every page. It now only shows when "Event Dashboard" from the main navbar is selected (and on subsequent pages reached through the subnav itself).
