### PR TITLE
#123 - Removes hint text from speaker and staff proposal show pages

### DIFF
--- a/app/views/proposals/_contents.html.haml
+++ b/app/views/proposals/_contents.html.haml
@@ -1,25 +1,16 @@
 .proposal-section
-  %h3.control-label Title
-  .markdown{ data: { 'field-id' => 'proposal_title' } }
-    = proposal.title
-  %p.help-block Publicly viewable title. Ideally catchy, interesting, essence of the talk. Limited to 60 characters.
-
-.proposal-section
   %h3.control-label Session Format
   = proposal.session_format.try(:name)
-  %p.help-block The format your proposal will follow.
 
 - if proposal.track
   .proposal-section
     %h3.control-label Track
     = proposal.track.name
-    %p.help-block Optional: suggest a specific track to be considered for.
 
 .proposal-section
   %h3.control-label Abstract
   .markdown{ data: { 'field-id' => 'proposal_abstract' } }
     = proposal.abstract_markdown
-  %p.help-block A concise, engaging description for the public program. Limited to 600 characters.
 
 -if proposal.event.public_tags?
   .proposal-section
@@ -28,17 +19,15 @@
 
 %h2.fieldset-legend For Review Committee
 
-.proposal-section  
+.proposal-section
   %h3.control-label Details
   .markdown{ data: { 'field-id' => 'proposal_details' } }
     = proposal.details_markdown
-  %p.help-block Include any pertinent details such as outlines, outcomes or intended audience
 
 .proposal-section
   %h3.control-label Pitch
   .markdown{ data: { 'field-id' => 'proposal_pitch' } }
     =proposal.pitch_markdown
-  %p.help-block Explain why this talk should be considered and what makes you qualified to speak on the topic.
 
 - if proposal.custom_fields.any?
   - proposal.proposal_data[:custom_fields].select do |key,value|

--- a/app/views/proposals/_reviewer_contents.html.haml
+++ b/app/views/proposals/_reviewer_contents.html.haml
@@ -2,7 +2,6 @@
   %h3.control-label Abstract
   .markdown{ data: { 'field-id' => 'proposal_abstract' } }
     = proposal.abstract_markdown
-  %p.help-block A concise, engaging description for the public program. Limited to 600 characters.
 
 -if proposal.event.public_tags?
   .proposal-section
@@ -11,17 +10,15 @@
 
 %h2.fieldset-legend For Review Committee
 
-.proposal-section  
+.proposal-section
   %h3.control-label Details
   .markdown{ data: { 'field-id' => 'proposal_details' } }
     = proposal.details
-  %p.help-block Include any pertinent details such as outlines, outcomes or intended audience
 
 .proposal-section
   %h3.control-label Pitch
   .markdown{ data: { 'field-id' => 'proposal_pitch' } }
     =proposal.pitch
-  %p.help-block Explain why this talk should be considered and what makes you qualified to speak on the topic.
 
 - if proposal.custom_fields.any?
   - proposal.proposal_data[:custom_fields].select do |key,value|


### PR DESCRIPTION
Hint text only shows on proposal form page
