### PR TITLE
#75 improve tooltips

### DIFF
--- a/app/assets/javascripts/base.js
+++ b/app/assets/javascripts/base.js
@@ -1,6 +1,7 @@
 $(document).ready(function() {
   $("#gravatar-alert").tooltip();
-  $('body').tooltip({selector: "[data-toggle~='tooltip']", html: true})
+  $('body').tooltip({selector: "[data-toggle~='tooltip']", html: true});
+  $('body').popover({selector: "[data-toggle~='popover']", html: true, trigger: 'manual'});
 });
 
 // Datatable extension for reseting sort order

--- a/app/assets/javascripts/proposal.js
+++ b/app/assets/javascripts/proposal.js
@@ -12,6 +12,7 @@ $(function() {
       });
     });
   }
+
   $('.js-maxlength-alert').keyup(function() {
     var maxlength = $(this).attr('maxlength');
     var current_length = $(this).val().length;
@@ -19,10 +20,23 @@ $(function() {
       alert("Character limit of " + maxlength + " has been exceeded");
     }
   });
-});
 
-$(function() {
   $('.speaker-invite-button').click(function() {
     $('.speaker-invite-form').toggle();
+  });
+
+  // Manually show the popover for clicked-on element, and dismiss all
+  // other popovers when new one displayed.
+  $(document).on('click', '.popover-trigger', function(ev) {
+    var selector = $(this).data('target');
+    var toggle = $(selector);
+    $.each($("[data-toggle~='popover']"), function(i, pop) {
+      pop = $(pop);
+      if (pop.is(toggle)) {
+        pop.popover('toggle');
+      } else {
+        pop.popover('hide');
+      }
+    });
   });
 });

--- a/app/assets/stylesheets/base/_variables.scss
+++ b/app/assets/stylesheets/base/_variables.scss
@@ -24,6 +24,7 @@ $gray-dark:              lighten($gray-base, 20%) !default;   // #333
 $gray:                   lighten($gray-base, 33.5%) !default; // #555
 $gray-light:             #b2afaa !default; //lighten($gray-base, 46.7%) !default; // #777
 $gray-lighter:           lighten($gray-base, 93.5%) !default; // #eee
+$beige:                  #f9f6f1;
 
 $brand-primary:         $ruby-central-red !default; //darken(#428bca, 6.5%) !default; // #337ab7
 $brand-success:         $green !default;
@@ -554,13 +555,13 @@ $tooltip-arrow-color:         $tooltip-bg !default;
 //##
 
 //** Popover body background color
-$popover-bg:                          #fff !default;
+$popover-bg:                          $beige;
 //** Popover maximum width
 $popover-max-width:                   276px !default;
 //** Popover border color
 $popover-border-color:                rgba(0,0,0,.2) !default;
 //** Popover fallback border color
-$popover-fallback-border-color:       #ccc !default;
+$popover-fallback-border-color:       $state-info-border !default;
 
 //** Popover title background color
 $popover-title-bg:                    darken($popover-bg, 3%) !default;

--- a/app/assets/stylesheets/modules/_buttons.scss
+++ b/app/assets/stylesheets/modules/_buttons.scss
@@ -33,3 +33,18 @@
 .invite-btn {
   margin-bottom: 25px !important;
 }
+
+.btn-icon {
+  padding: 0;
+}
+
+.hint-btn {
+  color: $brand-info;
+  cursor: pointer;
+  font-size: $font-size-large;
+
+  &:active,
+  &:focus {
+    color: $brand-info;
+  }
+}

--- a/app/assets/stylesheets/modules/_shortcuts.scss
+++ b/app/assets/stylesheets/modules/_shortcuts.scss
@@ -7,7 +7,7 @@
 }
 
 .shortcuts .shortcut {
-  background: #f9f6f1;
+  background: $beige;
   display: inline-block;
   margin: 0 .9% 1em;
   padding: 12px 0;

--- a/app/assets/stylesheets/modules/_widgets.scss
+++ b/app/assets/stylesheets/modules/_widgets.scss
@@ -12,11 +12,11 @@
   }
 
   .widget-header {
-    background: #f9f6f1;
+    background: $beige;
     border: 1px solid #d6d6d6;
     height: 40px;
     line-height: 40px;
-    @include gradient-vertical(#f9f6f1, #f2efea, 0%, 100%);
+    @include gradient-vertical($beige, #f2efea, 0%, 100%);
     -webkit-background-clip: padding-box;
     background-clip: padding-box;
 
@@ -117,12 +117,12 @@
 }
 
 .widget-card {
-  background: #f9f6f1;
+  background: $beige;
   padding: 15px;
 
   .widget-header,
   .widget-content {
-    background: #f9f6f1;
+    background: $beige;
     border: none;
     border-radius: 0;
     padding: 15px 0;

--- a/app/decorators/proposal_decorator.rb
+++ b/app/decorators/proposal_decorator.rb
@@ -123,7 +123,7 @@ class ProposalDecorator < ApplicationDecorator
   def abstract_input(form, tooltip = "Proposal Abstract")
     form.input :abstract,
       maxlength: 605, input_html: { class: 'watched js-maxlength-alert', rows: 5 },
-      hint: 'A concise, engaging description for the public program. Limited to 600 characters.', tooltip: tooltip
+      hint: 'A concise, engaging description for the public program. Limited to 600 characters.'#, popover_icon: { content: tooltip }
   end
 
   private

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -79,4 +79,5 @@ module ApplicationHelper
   def body_id
     "#{controller_path.tr('/','_')}_#{action_name}"
   end
+
 end

--- a/app/helpers/proposal_helper.rb
+++ b/app/helpers/proposal_helper.rb
@@ -15,23 +15,23 @@ module ProposalHelper
   end
 
   def track_tooltip
-    "Track Tooltip!"
+    "Optional: suggest a specific track to be considered for."
   end
 
   def abstract_tooltip
-    "Abstract Tooltip!"
+    "A concise, engaging description for the public program. Limited to 600 characters."
   end
 
   def details_tooltip
-    "Details tooltip"
+    "Include any pertinent details such as outlines, outcomes or intended audience."
   end
 
   def pitch_tooltip
-    "Pitch Tooltip"
+    "Explain why this talk should be considered and what makes you qualified to speak on the topic."
   end
 
   def bio_tooltip
-    "Tell us a bit about yourself!"
+    "Your bio should be short, no longer than 500 characters. It's related to why you're speaking about this topic."
   end
 
 end

--- a/app/views/proposals/_form.html.haml
+++ b/app/views/proposals/_form.html.haml
@@ -4,19 +4,23 @@
   - opts_session_formats = event.session_formats.publicly_viewable.map {|st| [st.name, st.id]}
 
   - if opts_session_formats.length > 1
-    = f.association :session_format, collection: opts_session_formats, include_blank: 'None selected', required: true, input_html: {class: 'dropdown'}, hint: "The format your proposal will follow.", tooltip: ["right", session_format_tooltip]
+    = f.association :session_format, collection: opts_session_formats, include_blank: 'None selected', required: true, input_html: {class: 'dropdown'},
+      hint: "The format your proposal will follow."#, popover_icon: { content: session_format_tooltip }
   - else
-    = f.association :session_format, collection: opts_session_formats, include_blank: false, input_html: {readonly: "readonly"}, hint: "The format your proposal will follow.", tooltip: ["right", "Only One Session Format for #{event.name}"]
+    = f.association :session_format, collection: opts_session_formats, include_blank: false, input_html: {readonly: "readonly"},
+      hint: "The format your proposal will follow."#, popover_icon: { content: "Only One Session Format for #{event.name}" }
 
   - opts_tracks = event.tracks.map {|t| [t.name, t.id]}
   -if opts_tracks.length > 0
-    = f.association :track, collection: opts_tracks, include_blank: 'None selected', input_html: {class: 'dropdown'}, hint: "Optional: suggest a specific track to be considered for.", tooltip: ["right", track_tooltip]
+    = f.association :track, collection: opts_tracks, include_blank: 'None selected', input_html: {class: 'dropdown'},
+      hint: "Optional: suggest a specific track to be considered for."#, popover_icon: { content: track_tooltip }
 
   = proposal.abstract_input(f, abstract_tooltip)
 
   - if event.public_tags?
     .form-group
-      %h3.control-label Tags
+      %h3.control-label 
+        Tags
       = f.select :tags,
         options_for_select(event.proposal_tags, proposal.object.tags),
         {}, {class: 'multiselect proposal-tags', multiple: true }
@@ -27,10 +31,10 @@
     This content will <strong> only</strong> be visible to the review committee.
 
   = f.input :details, input_html: { class: 'watched', rows: 5 },
-    hint: 'Include any pertinent details such as outlines, outcomes or intended audience.', tooltip: ["right", details_tooltip]
+    hint: 'Include any pertinent details such as outlines, outcomes or intended audience.'#, popover_icon: { content: details_tooltip }
 
   = f.input :pitch, input_html: { class: 'watched', rows: 5 }, 
-    hint: 'Explain why this talk should be considered and what makes you qualified to speak on the topic.', tooltip: ["right", pitch_tooltip]
+    hint: 'Explain why this talk should be considered and what makes you qualified to speak on the topic.'#, popover_icon: { content: pitch_tooltip }
 
 - if event.custom_fields.any?
   - event.custom_fields.each do |custom_field|

--- a/app/views/speakers/_fields.html.haml
+++ b/app/views/speakers/_fields.html.haml
@@ -7,4 +7,4 @@
 
     = speaker_fields.input :name, disabled: true, tooltip: ["right", "Edit your profile to update"]
 
-    = speaker_fields.input :bio, maxlength: :lookup, input_html: { value: speaker.bio, rows: 4 }, hint: 'Your bio should be short, no longer than 500 characters. It\'s related to why you\'re speaking about this topic.', tooltip: bio_tooltip
+    = speaker_fields.input :bio, maxlength: :lookup, input_html: { value: speaker.bio, rows: 4 }, hint: "Your bio should be short, no longer than 500 characters. It's related to why you're speaking about this topic."#, popover_icon: { content: bio_tooltip }

--- a/config/initializers/simple_form/popover_icon_component.rb
+++ b/config/initializers/simple_form/popover_icon_component.rb
@@ -1,0 +1,66 @@
+module SimpleForm
+  module Components
+    module PopoverIcons
+      def popover_icon(wrapper_options = nil)
+        return if popover_content.blank?
+
+        input_html_options[:rel] ||= 'popover'
+        input_html_options[:data] ||= {}
+        input_html_options[:data][:toggle] ||= 'popover'
+        input_html_options[:data][:placement] ||= popover_placement if popover_placement
+        input_html_options[:data][:trigger] ||= 'manual'
+        input_html_options[:data]['original-title'] ||= popover_title if popover_title
+        input_html_options[:data][:content] ||= popover_content
+        input_html_options[:data][:animation] ||= false
+        input_html_options[:data][:container] ||= 'body'
+        nil
+      end
+
+      def icon
+        return if popover_content.blank?
+        template.capture do
+          template.content_tag(:a, class:'btn btn-icon hint-btn popover-trigger', data: { target: popover_selector }) do
+            template.content_tag(:i, '', class: 'fa fa-fw fa-question-circle')
+          end
+        end.html_safe
+      end
+
+      def label_text(wrapper_options = nil)
+        label_text = options[:label_text] || SimpleForm.label_text
+        label_text.call(html_escape(raw_label_text), required_label_text, options[:label].present?, icon).strip.html_safe
+      end
+
+      def popover_selector
+        selector = "##{@builder.object_name}_#{@attribute_name}"
+        selector.gsub!(/([^a-z0-9#]+)/i, '_')
+        selector += "_#{object.id}" if object.try(:id)
+        selector
+      end
+
+      def popover_content
+        popover = options[:popover_icon]
+        if popover.is_a?(String)
+          popover
+        elsif popover.is_a?(Hash)
+          popover[:content]
+        else
+          nil
+        end
+      end
+
+      def popover_title
+        popover = options[:popover_icon]
+        if popover.is_a?(Hash)
+          popover[:title]
+        end
+      end
+
+      def popover_placement
+        popover = options[:popover_icon]
+        popover.is_a?(Hash) ? popover[:placement] : 'right'
+      end
+    end
+  end
+end
+
+SimpleForm::Inputs::Base.send(:include, SimpleForm::Components::PopoverIcons)

--- a/config/initializers/simple_form_bootstrap.rb
+++ b/config/initializers/simple_form_bootstrap.rb
@@ -8,9 +8,10 @@ SimpleForm.setup do |config|
 
     b.use :html5
     b.use :placeholder
-    b.optional :tooltip
-    b.use :label, class: 'control-label'
     b.optional :maxlength
+    b.optional :tooltip
+    b.optional :popover_icon
+    b.use :label, class: 'control-label'
 
     b.wrapper tag: 'div' do |ba|
       ba.use :input, class: 'form-control'
@@ -23,6 +24,7 @@ SimpleForm.setup do |config|
     b.use :html5
     b.use :placeholder
     b.optional :tooltip
+    b.optional :popover_icon
     b.use :label, class: 'control-label'
 
     b.wrapper tag: 'div' do |ba|
@@ -36,6 +38,7 @@ SimpleForm.setup do |config|
     b.use :html5
     b.use :placeholder
     b.optional :tooltip
+    b.optional :popover_icon
 
     b.wrapper tag: 'div', class: 'checkbox' do |ba|
       ba.use :label_input
@@ -49,7 +52,9 @@ SimpleForm.setup do |config|
     b.use :html5
     b.use :placeholder
     b.optional :tooltip
+    b.optional :popover_icon
     b.use :label_input
+
     b.use :error, wrap_with: { tag: 'span', class: 'help-block' }
     b.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
   end
@@ -104,6 +109,9 @@ SimpleForm.setup do |config|
       ba.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
     end
   end
+
+  # Added support for help icon
+  config.label_text = lambda { |label, required, explicit_label, icon| "#{label} #{required} #{icon}" }
 
   # Wrappers for forms and inputs using the Bootstrap toolkit.
   # Check the Bootstrap docs (http://getbootstrap.com)


### PR DESCRIPTION
# WIP - Fixing tooltips

Need some help implementing this in the decorators we have for simple form.
### Changes
- Change tooltip hint to popover (Bootstrap implementation)
- Some CSS fixes to use a variable for this beige hex code that is used a few times in the code
### Notes/Questions

I think there are pros/cons to Bootstrap popovers, in general. 

**Pros:**
- It works out of the box. 
- It solves the click to show/hide issue. 
- Theoretically it supports HTML content so we can add a close button to make dismiss action more obvious, if we want.

**Cons:**
- It's still going to look a little funky once the content gets long. 
- If we want the speaker to be able to see hint text and edit at the same time, the popover might not work as a solution anymore (will likely cover part of the input fields).

I have a local branch where I'm experimenting with a slide-in thing, but it's really half-baked at the moment. Needs to work on mobile and need to inject in the right place in the DOM and position the content correctly so it shows up close to the relevant form field. Definitely not ready for CFP live date.
### A really low-quality gif of Bootstrap Popover (thanks, RecordIt):

![](http://g.recordit.co/LVjGzGqDhP.gif)
### Experimental:

![](http://g.recordit.co/SsRJmkpKIL.gif)

(P.S. These gifs don't appear to show the cursor pointer that shows up when you hover over the icon, because RecordIt apparently sucks.)

@mghaught @PenneyGadget 
