### PR TITLE
#122 Smoothing out OAuth flows.

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -8,7 +8,7 @@ class ProfilesController < ApplicationController
   end
 
   def update
-    if current_user.update_attributes(user_params) && current_user.complete?
+    if current_user.update_attributes(user_params)
       current_user.assign_open_invitations if session[:need_to_complete]
 
       if current_user.unconfirmed_email.present?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,8 +26,8 @@ class User < ActiveRecord::Base
   validates :name, presence: true, allow_nil: true
   validates_uniqueness_of :email, allow_blank: true
   validates_format_of :email, with: Devise.email_regexp, allow_blank: true, if: :email_changed?
-  validates_presence_of :email, on: :create, if: -> { provider.nil? }
-  validates_presence_of :email, on: :update
+  validates_presence_of :email, on: :create, if: -> { provider.blank? }
+  validates_presence_of :email, on: :update, if: -> { provider.blank? || unconfirmed_email.blank? }
   validates_presence_of :password, on: :create
   validates_confirmation_of :password, on: :create
   validates_length_of :password, within: Devise.password_length, allow_blank: true

--- a/app/views/profiles/edit.html.haml
+++ b/app/views/profiles/edit.html.haml
@@ -36,7 +36,9 @@
             Email is only used for notifications on proposal feedback and acceptance into the program.
           .form-group
             = f.label :email
-            = f.email_field :email, class: 'form-control', placeholder: 'Your email address'
+            = f.email_field :email, class: 'form-control', placeholder: 'Your email address', value: current_user.unconfirmed_email.present? ? current_user.unconfirmed_email : current_user.email
+            - if current_user.unconfirmed_email.present?
+              %p.help-block This email has not been confirmed yet.
           .form-group
             = f.label :password
             = f.password_field :password, class: 'form-control', placeholder: 'Password'

--- a/spec/features/profile_spec.rb
+++ b/spec/features/profile_spec.rb
@@ -27,7 +27,7 @@ feature 'User Profile' do
     expect(user.bio).to eq('I am even more awesome')
   end
 
-  scenario "A user attempts to save their bio without email" do
+  scenario "A user attempts to save their bio without email", js: true do
     visit (edit_profile_path)
     fill_in('Email', with: '')
     click_button 'Save'

--- a/spec/features/proposal_spec.rb
+++ b/spec/features/proposal_spec.rb
@@ -36,7 +36,7 @@ feature "Proposals" do
       end
 
       it "submits unsuccessfully" do
-        expect(page).to have_text("There was a problem saving your proposal; please review the form for issues and try again.")
+        expect(page).to have_text("There was a problem saving your proposal.")
       end
 
       it "shows Title validation if blank on submit" do


### PR DESCRIPTION
- Fixed issue where profile wouldn't save, or would appear not to save, following OAuth signin.
- Profile will show unconfirmed email address if email isn't available.
