### PR TITLE
#127 Display incomplete events

### DIFF
--- a/app/decorators/event_decorator.rb
+++ b/app/decorators/event_decorator.rb
@@ -43,7 +43,7 @@ class EventDecorator < ApplicationDecorator
   end
 
   def closes_at(format = nil)
-    if format
+    if format && object.closes_at
       object.closes_at.to_s(format)
     else
       object.closes_at

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -44,17 +44,14 @@
         %div
           = link_to 'Submit a proposal', new_event_proposal_path, class: 'btn btn-primary'
     - else
-      .panel.panel-default
-        .panel-heading
-          CFP
-          = event.status
-        .panel-body
-          %dl.event-cfp-data
-            %dt
-              CFP closed:
-            %dd
-              = event.closes_at(:long_with_zone)
-
+      .event-info.event-info-block.callout
+        .call-header
+          .label.label-success.label-large.inline-block
+            CFP
+            = event.status
+          .panel-body
+            %p The CFP has not yet opened.  
+            %p Please check back soon!
 
     - if event.proposals.count > 5
       .stats

--- a/spec/features/current_event_user_flow_spec.rb
+++ b/spec/features/current_event_user_flow_spec.rb
@@ -167,6 +167,8 @@ feature "A user sees correct information for the current event and their role" d
       expect(page).to have_link(event_1.name)
     end
 
+    click_on "Event Dashboard"
+    
     within ".subnavbar" do
       expect(page).to have_content("Dashboard")
       expect(page).to have_content("Info")

--- a/spec/features/proposal_spec.rb
+++ b/spec/features/proposal_spec.rb
@@ -134,9 +134,9 @@ feature "Proposals" do
       expect(page).to have_text("Here's a comment for you!")
     end
 
-    it "it shows the speaker's name" do
+    it "it does not show the speaker's name" do
       within(:css, '.speaker-comment') do
-        expect(page).to have_text(user.name)
+        expect(page).to have_text("speaker")
       end
     end
   end


### PR DESCRIPTION
Fixes issue where a draft CFP was returning a 500 if the closes_at date was not set
