### PR TITLE
#128 Cleans up event management pages

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -64,3 +64,4 @@
 @import "modules/stats";
 @import "modules/tooltips";
 @import "modules/widgets";
+@import "modules/teammates";

--- a/app/assets/stylesheets/modules/_proposal.scss
+++ b/app/assets/stylesheets/modules/_proposal.scss
@@ -144,7 +144,7 @@ div.col-md-4 {
     position:relative;
     margin-top: -0.1em;
   }
-  
+
   .proposal-title {
     margin-top: 0;
     margin-bottom: $padding-base-vertical;

--- a/app/assets/stylesheets/modules/_teammates.scss
+++ b/app/assets/stylesheets/modules/_teammates.scss
@@ -1,0 +1,16 @@
+.teammate-info-bar {
+
+  margin-top: 15px;
+
+  .teammate-meta {
+    font-size: $font-size-small;
+    color: $gray;
+
+    .teammate-meta-item {
+      display: inline-block;
+      margin-right: $padding-base-horizontal;
+      font-size: $font-size-small;
+      color: $gray;
+    }
+  }
+}

--- a/app/controllers/teammates_controller.rb
+++ b/app/controllers/teammates_controller.rb
@@ -6,14 +6,14 @@ class TeammatesController < ApplicationController
   def accept
     if !current_user
       session[:pending_invite] = accept_teammate_url(@teammate_invitation.token)
-      flash[:info] = "Thanks for joining #{current_event.name}!"
+      flash[:info] = "Team invite to #{current_event.name} accepted!"
     else
       if already_teammate?
         flash[:danger] = "You are already a teammate for #{current_event.name}"
         redirect_to event_staff_teammates_path(current_event)
       else
         @teammate_invitation.accept(current_user)
-        flash[:info] = "Thanks for joining #{current_event.name}!"
+        flash[:info] = "Team invite to #{current_event.name} accepted!"
         if current_user.complete?
           session.delete :pending_invite
           flash[:info] = "Congrats! You are now an official team member of #{current_event.name}!"

--- a/app/views/staff/events/show.html.haml
+++ b/app/views/staff/events/show.html.haml
@@ -97,32 +97,32 @@
                 %td.text-primary
                   %strong Event Url:
                 - if event.url.present?
-                  %td.set= link_to "Set", event_staff_edit_path
+                  %td.set= link_to "Set", event_staff_info_path
                 - else
-                  %td.missing= link_to "Missing", event_staff_edit_path
+                  %td.missing= link_to "Missing", event_staff_info_path
               %tr
                 %td.text-primary
                   %strong Event Dates:
                 - if event.start_date.present? && event.end_date.present?
-                  %td.set= link_to "Set", event_staff_edit_path
+                  %td.set= link_to "Set", event_staff_info_path
                 - else
-                  %td.missing= link_to "Missing", event_staff_edit_path
+                  %td.missing= link_to "Missing", event_staff_info_path
               %tr
                 %td.text-primary
                   %strong Contact Email:
                 - if event.contact_email.present?
-                  %td.set= link_to "Set", event_staff_edit_path
+                  %td.set= link_to "Set", event_staff_info_path
                 - else
-                  %td.missing= link_to "Missing", event_staff_edit_path
+                  %td.missing= link_to "Missing", event_staff_info_path
               %tr
                 %td.text-primary
                   %strong CFP Closes Date:
                 - if event.closes_at && (event.closes_at > Time.current)
-                  %td.set= link_to "Set", event_staff_edit_path
+                  %td.set= link_to "Set", event_staff_info_path
                 -elsif event.closes_at && (event.closes_at <= Time.current)
-                  %td.missing= link_to "Date has Passed", event_staff_edit_path
+                  %td.missing= link_to "Date has Passed", event_staff_info_path
                 - else
-                  %td.missing= link_to "Missing", event_staff_edit_path
+                  %td.missing= link_to "Missing", event_staff_info_path
               %tr
                 %td.text-primary
                   %strong Public Session Formats:
@@ -135,6 +135,20 @@
                   %strong Tracks:
                 - if event.tracks.present?
                   %td.set= link_to event.tracks.count, event_staff_config_path
+                - else
+                  %td.optional= link_to "None (optional)", event_staff_config_path
+              %tr
+                %td.text-primary
+                  %strong Proposal Tags:
+                - if event.proposal_tags.present?
+                  %td.set= link_to event.proposal_tags.count, event_staff_config_path
+                - else
+                  %td.optional= link_to "None (optional)", event_staff_config_path
+              %tr
+                %td.text-primary
+                  %strong Review Tags:
+                - if event.review_tags.present?
+                  %td.set= link_to event.review_tags.count, event_staff_config_path
                 - else
                   %td.optional= link_to "None (optional)", event_staff_config_path
               %tr

--- a/app/views/staff/teammates/index.html.haml
+++ b/app/views/staff/teammates/index.html.haml
@@ -2,25 +2,21 @@
   .col-md-12
     .page-header.clearfix
       %h1 Event Staff
-      %hr
 
-      .row
-        .col-md-4
-          .widget
-            .widget-header
-              %i.fa.fa-users
-              %h3 Team Count
-            .widget-content
-              %h4
-                = pluralize(@staff_count["organizer"], "organizer")
-                %em.pending= "(" + pluralize(@pending_invite_count["organizer"], "pending invitation") + ")"
-                %hr
-                = @staff_count["program team"]
-                program team
-                %em.pending= "(" + pluralize(@pending_invite_count["program team"], "pending invitation") + ")"
-                %hr
-                = pluralize(@staff_count["reviewer"], "reviewer")
-                %em.pending= "(" + pluralize(@pending_invite_count["reviewer"], "pending invitation") + ")"
+      .teammate-info-bar
+        .teammate-meta
+          .teammate-meta-item
+            %strong= pluralize(@staff_count["organizer"], "organizer")
+            %span= "(" + pluralize(@pending_invite_count["organizer"], "pending invitation") + ")"
+          .teammate-meta-item
+            %strong= @staff_count["program team"]
+            %strong
+              program team
+            %span= "(" + pluralize(@pending_invite_count["program team"], "pending invitation") + ")"
+          .teammate-meta-item
+            %strong= pluralize(@staff_count["reviewer"], "reviewer")
+            %span= "(" + pluralize(@pending_invite_count["reviewer"], "pending invitation") + ")"
+          %hr
 
       .row
         .col-md-12

--- a/app/views/teammates/accept.html.haml
+++ b/app/views/teammates/accept.html.haml
@@ -1,8 +1,8 @@
 .row
   .col-sm-12.text-center
-    %h2.margin-top= "Thank you for joining the #{@current_event.name} team!"
-    %br
-    %h3
-      %span.label.label-default= link_to "Sign In", new_user_session_path
-      or
-      %span.label.label-default= link_to "Create an Account", new_user_registration_path
+    %h2.margin-top= "Thanks for joining our team."
+    To get started
+    %button.btn-lg.btn-default= link_to "Create your Account", new_user_registration_path
+
+    If you already have an account,
+    %span= link_to "Log in.", new_user_session_path

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -38,7 +38,7 @@ best_track = seed_event.tracks.create(name: 'Best Track', description: 'Better t
 
 # Event Team
 seed_event.teammates.create(user: organizer, email: organizer.email, role: "organizer", state: Teammate::ACCEPTED, notifications: false)
-seed_event.teammates.create(user: track_director, email: track_director.email, role: "organizer", state: Teammate::ACCEPTED) # < update to program team
+seed_event.teammates.create(user: track_director, email: track_director.email, role: "program team", state: Teammate::ACCEPTED)
 seed_event.teammates.create(user: reviewer, email: reviewer.email, role: "reviewer", state: Teammate::ACCEPTED)
 seed_event.teammates.create(user: speaker_reviewer, email: speaker_reviewer.email, role: "reviewer", state: Teammate::ACCEPTED)
 

--- a/spec/features/staff/teammate_invitation_spec.rb
+++ b/spec/features/staff/teammate_invitation_spec.rb
@@ -14,10 +14,10 @@ feature "Teammate Invitations" do
     it "can accept the invitation" do
       visit accept_teammate_path(invitation.token)
 
-      expect(page).to have_content("Thanks for joining #{invitation.event.name}!")
-      expect(page).to have_content("Thank you for joining the #{invitation.event.name} team!")
-      expect(page).to have_link("Sign In")
-      expect(page).to have_link("Create an Account")
+      expect(page).to have_content("Team invite to #{invitation.event.name} accepted!")
+      expect(page).to have_content("Thanks for joining our team.")
+      expect(page).to have_link("Log in")
+      expect(page).to have_button("Create your Account")
     end
 
     it "a logged in user can accept an invitation" do


### PR DESCRIPTION
- Changes flash and message on teammate invite accept page & fixes corresponding test
- Shrinks team count info on staff team page to match event info bar
- Changes CFP checklist items on staff event dashboard to do to show page instead of edit
- Adds proposal tags and review tags to CFP checklist
- Changes track directors role in seeds file to program team
