### PR TITLE
#120 restrict event edits

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -405,5 +405,8 @@ DEPENDENCIES
   web-console (~> 2.0)
   zeroclipboard-rails
 
+RUBY VERSION
+   ruby 2.3.0p0
+
 BUNDLED WITH
    1.12.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,7 +114,7 @@ GEM
     factory_girl_rails (4.5.0)
       factory_girl (~> 4.5.0)
       railties (>= 3.0.0)
-    faker (1.6.1)
+    faker (1.6.6)
       i18n (~> 0.5)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)

--- a/app/controllers/staff/events_controller.rb
+++ b/app/controllers/staff/events_controller.rb
@@ -2,6 +2,7 @@ class Staff::EventsController < Staff::ApplicationController
   before_action :enable_staff_subnav
 
   def edit
+    authorize @event, :edit?
   end
 
   def show
@@ -21,6 +22,7 @@ class Staff::EventsController < Staff::ApplicationController
   end
 
   def update_guidelines
+    authorize_update
     if @event.update(params.require(:event).permit(:guidelines))
       flash[:info] = 'Your guidelines were updated.'
       redirect_to event_staff_guidelines_path
@@ -34,6 +36,7 @@ class Staff::EventsController < Staff::ApplicationController
   end
 
   def update_status
+    authorize_update
     if @event.update(params.require(:event).permit(:state))
       redirect_to event_staff_info_path(@event), notice: 'Event status was successfully updated.'
     else
@@ -46,6 +49,7 @@ class Staff::EventsController < Staff::ApplicationController
   end
 
   def update_custom_fields
+    authorize_update
     @event.update_attributes(event_params)
     respond_to do |format|
       format.js do
@@ -55,6 +59,7 @@ class Staff::EventsController < Staff::ApplicationController
   end
 
   def update_reviewer_tags
+    authorize_update
     @event.update(params.require(:event).permit(:valid_review_tags))
     respond_to do |format|
       format.js do
@@ -64,6 +69,7 @@ class Staff::EventsController < Staff::ApplicationController
   end
 
   def update_proposal_tags
+    authorize_update
     @event.update(params.require(:event).permit(:valid_proposal_tags))
     respond_to do |format|
       format.js do
@@ -73,6 +79,7 @@ class Staff::EventsController < Staff::ApplicationController
   end
 
   def update
+    authorize_update
     if @event.update_attributes(event_params)
       flash[:info] = 'Your event was saved.'
       redirect_to event_staff_info_path(@event)
@@ -83,6 +90,7 @@ class Staff::EventsController < Staff::ApplicationController
   end
 
   def open_cfp
+    authorize_update
     if @event.open_cfp
       flash[:info] = "Your CFP was successfully opened."
     else
@@ -99,5 +107,9 @@ class Staff::EventsController < Staff::ApplicationController
         :valid_review_tags, :custom_fields_string, :state, :guidelines,
         :closes_at, :speaker_notification_emails, :accept, :reject,
         :waitlist, :opens_at, :start_date, :end_date)
+  end
+
+  def authorize_update
+    authorize @event, :update?
   end
 end

--- a/app/views/staff/events/_speaker_notifications_form.html.haml
+++ b/app/views/staff/events/_speaker_notifications_form.html.haml
@@ -27,9 +27,7 @@
           %br
           %code ::This is my link text|confirmation_link::
         %p.help-block * confirmation link is not available in Reject emails
-
-        %button.pull-right.btn.btn-lg.btn-success{type: "submit"} Save
-
-
-
-
+        %br
+        %br
+        - if current_user.organizer_for_event?(event)
+          %button.pull-left.btn.btn-lg.btn-success{type: "submit"} Save

--- a/app/views/staff/events/speaker_emails.html.haml
+++ b/app/views/staff/events/speaker_emails.html.haml
@@ -2,12 +2,9 @@
   .col-md-12
     .page-header
       %h1
-        Edit #{event} Speaker Email Notifications
-        -if params[:form].present?
-          \-
-          %em=params[:form].humanize.gsub("form", "")
+        #{event} Speaker Email Notifications
 
 .row
   .col-md-12
     = form_for event, url: event_staff_update_path(event), html: {role: 'form'} do |f|
-      = render partial: "admin/events/speaker_notifications_form", locals: {f: f}
+      = render partial: "speaker_notifications_form", locals: {f: f}

--- a/spec/factories/session_formats.rb
+++ b/spec/factories/session_formats.rb
@@ -1,7 +1,8 @@
 FactoryGirl.define do
   factory :session_format do
     event { Event.first || FactoryGirl.create(:event) }
-    name "Default Format"
+    name Faker::Book.genre
+    description Faker::Company.catch_phrase
     duration 30
     add_attribute :public, true
   end

--- a/spec/factories/tracks.rb
+++ b/spec/factories/tracks.rb
@@ -2,6 +2,7 @@
 
 FactoryGirl.define do
   factory :track do
-    name "MyText"
+    name Faker::Superhero.name
+    description Faker::Company.catch_phrase
   end
 end

--- a/spec/features/current_event_user_flow_spec.rb
+++ b/spec/features/current_event_user_flow_spec.rb
@@ -228,7 +228,7 @@ feature "A user sees correct information for the current event and their role" d
     end
 
     click_on "Speaker Emails"
-    expect(page).to have_content "Edit #{event_2.name} Speaker Email Notifications"
+    expect(page).to have_content "#{event_2.name} Speaker Email Notifications"
 
     speaker = create(:speaker, event: event_2, user: organizer_user)
     proposal.speakers << speaker

--- a/spec/features/staff/edit_guidelines_spec.rb
+++ b/spec/features/staff/edit_guidelines_spec.rb
@@ -6,7 +6,7 @@ feature "Event Guidelines" do
   let!(:admin_teammate) { create(:teammate,
                                    event: event,
                                    user: admin_user,
-                                   role: 'organizer'
+                                   role: "organizer"
                                   )
   }
 
@@ -14,21 +14,28 @@ feature "Event Guidelines" do
   let!(:event_staff_teammate) { create(:teammate,
                                        event: event,
                                        user: organizer_user,
-                                       role: 'organizer')
+                                       role: "organizer")
   }
 
   let(:reviewer_user) { create(:user) }
   let!(:reviewer_teammate) { create(:teammate,
                                       event: event,
                                       user: reviewer_user,
-                                      role: 'reviewer')
+                                      role: "reviewer")
   }
 
-  context "An admin" do
+  let(:program_team_user) { create(:user) }
+  let!(:program_team_teammate) { create(:teammate,
+                                      event: event,
+                                      user: program_team_user,
+                                      role: "program team")
+  }
+
+  context "An admin organizer" do
     before { login_as(admin_user) }
 
     it "can edit event guidelines", js: true do
-      visit event_staff_guidelines_path(event.slug)
+      visit event_staff_guidelines_path(event)
 
       expect(page).to have_button "Edit Guidelines"
       expect(page).to have_content "We want all the good talks!"
@@ -54,7 +61,7 @@ feature "Event Guidelines" do
     before { login_as(organizer_user) }
 
     it "can edit event guidelines", js: true do
-      visit event_staff_guidelines_path(event.slug)
+      visit event_staff_guidelines_path(event)
 
       expect(page).to have_button "Edit Guidelines"
       expect(page).to have_content "We want all the good talks!"
@@ -79,8 +86,19 @@ feature "Event Guidelines" do
   context "A reviewer" do
     before { login_as(reviewer_user) }
 
-    it "can NOT edit event guidelines", js: true do
-      visit event_staff_guidelines_path(event.slug)
+    it "cannot edit event guidelines", js: true do
+      visit event_staff_guidelines_path(event)
+
+      expect(page).to_not have_button "Edit Guidelines"
+      expect(page).to have_content "We want all the good talks!"
+    end
+  end
+
+  context "A program team" do
+    before { login_as(program_team_user) }
+
+    it "cannot edit event guidelines", js: true do
+      visit event_staff_guidelines_path(event)
 
       expect(page).to_not have_button "Edit Guidelines"
       expect(page).to have_content "We want all the good talks!"

--- a/spec/features/staff/event_spec.rb
+++ b/spec/features/staff/event_spec.rb
@@ -8,9 +8,15 @@ feature "Event Dashboard" do
   }
 
   let(:reviewer_user) { create(:user) }
-  let!(:reviewer_event_teammate) { create(:teammate,
+  let!(:reviewer_teammate) { create(:teammate,
                                       user: reviewer_user,
-                                      role: 'reviewer')
+                                      role: "reviewer")
+  }
+
+  let(:program_team_user) { create(:user) }
+  let!(:program_team_teammate) { create(:teammate,
+                                      user: program_team_user,
+                                      role: "program_team")
   }
 
   context "As an organizer" do
@@ -28,10 +34,17 @@ feature "Event Dashboard" do
     end
 
     it "can edit events" do
-      visit event_staff_edit_path(organizer_teammate.event)
+      visit event_staff_info_path(organizer_teammate.event)
+      expect(page).to have_content organizer_teammate.event.name
+      expect(page).to have_link "Edit Info"
+      expect(page).to have_link "Change Status"
+
+      click_on "Edit Info"
+
       fill_in "Name", with: "Blef"
-      click_button 'Save'
+      click_button "Save"
       expect(page).to have_text("Blef")
+      expect(current_path).to eq(event_staff_info_path(organizer_teammate.event))
     end
 
     it "can change event status" do
@@ -51,8 +64,44 @@ feature "Event Dashboard" do
     end
 
     it "cannot delete events" do
-      visit event_staff_url(organizer_teammate.event)
-      expect(page).not_to have_link('Delete Event')
+      visit event_staff_path(organizer_teammate.event)
+      expect(page).not_to have_link("Delete Event")
+    end
+  end
+
+  context "As a reviewer" do
+    before :each do
+      logout
+      login_as(reviewer_user)
+    end
+
+    it "cannot vist event edit pages" do
+      visit event_staff_edit_path(reviewer_teammate.event)
+      expect(page).to have_content "You are not authorized to perform this action."
+    end
+
+    it "cannot see event edit buttons" do
+      visit event_staff_info_path(reviewer_teammate.event)
+      expect(page).not_to have_link "Edit Info"
+      expect(page).not_to have_link "Change Status"
+    end
+  end
+
+  context "As a program team" do
+    before :each do
+      logout
+      login_as(program_team_user)
+    end
+
+    it "cannot vist event edit pages" do
+      visit event_staff_edit_path(program_team_teammate.event)
+      expect(page).to have_content "You are not authorized to perform this action."
+    end
+
+    it "cannot see event edit buttons" do
+      visit event_staff_info_path(program_team_teammate.event)
+      expect(page).not_to have_link "Edit Info"
+      expect(page).not_to have_link "Change Status"
     end
   end
 end

--- a/spec/features/staff/speaker_emails_spec.rb
+++ b/spec/features/staff/speaker_emails_spec.rb
@@ -1,0 +1,102 @@
+require 'rails_helper'
+
+feature "Speaker Emails" do
+  let(:event) { create(:event, name: "My Event") }
+  let(:admin_user) { create(:user, admin: true) }
+  let!(:admin_teammate) { create(:teammate,
+                                   event: event,
+                                   user: admin_user,
+                                   role: "organizer"
+                                  )
+  }
+
+  let(:organizer_user) { create(:user) }
+  let!(:event_staff_teammate) { create(:teammate,
+                                       event: event,
+                                       user: organizer_user,
+                                       role: "organizer")
+  }
+
+  let(:reviewer_user) { create(:user) }
+  let!(:reviewer_teammate) { create(:teammate,
+                                      event: event,
+                                      user: reviewer_user,
+                                      role: "reviewer")
+  }
+
+  let(:program_team_user) { create(:user) }
+  let!(:program_team_teammate) { create(:teammate,
+                                      event: event,
+                                      user: program_team_user,
+                                      role: "program team")
+  }
+
+  context "An admin organizer" do
+    before { login_as(admin_user) }
+
+    it "can edit speaker emails", js: true do
+      visit event_staff_speaker_email_notifications_path(event)
+
+      expect(page).to have_button "Save"
+
+      fill_in "event[accept]", with: "Yay! You've been accepted to speak!"
+      click_on "Save"
+
+      expect(page).to have_content "Your event was saved."
+      expect(current_path).to eq(event_staff_info_path(event))
+
+      visit event_staff_speaker_email_notifications_path(event)
+
+      within "#event_accept" do
+        expect(page).to have_content("Yay! You've been accepted to speak!")
+      end
+    end
+  end
+
+  context "An organizer" do
+    before { login_as(organizer_user) }
+
+    it "can edit speaker emails", js: true do
+      visit event_staff_speaker_email_notifications_path(event)
+
+      expect(page).to have_button "Save"
+
+      fill_in "event[reject]", with: "Oh.. sorry..."
+      fill_in "event[waitlist]", with: "You have to wait!"
+      click_on "Save"
+
+      expect(page).to have_content "Your event was saved."
+      expect(current_path).to eq(event_staff_info_path(event))
+
+      visit event_staff_speaker_email_notifications_path(event)
+
+      within "#event_reject" do
+        expect(page).to have_content("Oh.. sorry...")
+      end
+
+      within "#event_waitlist" do
+        expect(page).to have_content("You have to wait!")
+      end
+    end
+  end
+
+  context "A reviewer" do
+    before { login_as(reviewer_user) }
+
+    it "cannot edit speaker emails", js: true do
+      visit event_staff_speaker_email_notifications_path(event)
+
+      expect(page).to_not have_button "Save"
+    end
+  end
+
+  context "A program_team" do
+    before { login_as(program_team_user) }
+
+    it "cannot edit speaker emails", js: true do
+      visit event_staff_speaker_email_notifications_path(event)
+
+      expect(page).to_not have_button "Save"
+    end
+  end
+end

--- a/spec/features/staff/teammates_spec.rb
+++ b/spec/features/staff/teammates_spec.rb
@@ -44,18 +44,17 @@ feature "Staff Organizers can manage teammates" do
     end
 
     it "removes a teammate", js: true do
-      pending "This test fails because the js alert box doesn't pop up in order to finish removing the teammate"
       visit event_staff_teammates_path(invitation.event)
-      row = find("tr#teammate-#{reviewer_teammate.id}")
+      find("tr#teammate-#{reviewer_teammate.id}")
 
       within "#teammate-role-#{reviewer_teammate.id}" do
-        click_link "Remove"
+        page.accept_confirm { click_on "Remove" }
       end
 
-      # page.accept_confirm { click_on "OK" }
-
-      expect(row).to_not have_content(reviewer_teammate.email)
-      expect(row).to_not have_content("reviewer")
+      expect(page).to have_content("#{reviewer_teammate.email} was removed.")
+      page.reset!
+      expect(page).not_to have_content(reviewer_teammate.email)
+      expect(page).not_to have_content("reviewer")
     end
   end
 
@@ -63,6 +62,21 @@ feature "Staff Organizers can manage teammates" do
     before :each do
       logout
       login_as(reviewer_user)
+    end
+
+    it "cannot view buttons to edit event or change status" do
+      visit event_staff_teammates_path(invitation.event)
+
+      expect(page).to_not have_link("Change Role")
+      expect(page).to_not have_link("Remove")
+      expect(page).to_not have_link("Invite new teammate")
+    end
+  end
+
+  context "A program team cannot edit other teammates" do
+    before :each do
+      logout
+      login_as(program_team_user)
     end
 
     it "cannot view buttons to edit event or change status" do


### PR DESCRIPTION
Changes redirects on event dashboard checklist so that non-organizers don't see edit pages. Also restricts their access to edit using pundit and hides "save" button on speaker emails page. 
