### PR TITLE
#132 Changes to App Root

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -4,7 +4,7 @@ class EventsController < ApplicationController
 
   def index
     render locals: {
-      events: Event.recent.decorate
+      events: Event.not_draft.closes_up.decorate
     }
   end
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -25,8 +25,10 @@ class Event < ActiveRecord::Base
   store_accessor :speaker_notification_emails, :waitlist
 
 
-  scope :recent, -> { order('name ASC') }
-  scope :live, -> { where("state = 'open' and (closes_at is null or closes_at > ?)", Time.current).order('closes_at ASC') }
+  scope :a_to_z, -> { order('name ASC') }
+  scope :closes_up, -> { order('closes_at ASC') }
+  scope :live, -> { where("state = 'open' and (closes_at is null or closes_at > ?)", Time.current) }
+  scope :not_draft, -> { where "state != 'draft'"}
 
   validates :name, presence: true
   validates :slug, presence: true, uniqueness: true

--- a/app/views/events/index.html.haml
+++ b/app/views/events/index.html.haml
@@ -1,7 +1,5 @@
 - events.each do |event|
   .event
     %h1
-      = event.event_path_for
+      = link_to event.name, event_path(event.slug), class: 'event-title'
       %small= event.status
-
-    %span= link_to "View #{event.name}'s Guidelines", event_path(event.slug), class: 'guidelines-link'

--- a/spec/features/current_event_user_flow_spec.rb
+++ b/spec/features/current_event_user_flow_spec.rb
@@ -67,7 +67,7 @@ feature "A user sees correct information for the current event and their role" d
     expect(page).to have_link(event_1.name)
     expect(page).to have_link(event_2.name)
 
-    click_on("View #{event_1.name}'s Guidelines")
+    click_on(event_1.name)
 
     within ".navbar" do
       expect(page).to have_link(event_1.name)
@@ -83,7 +83,7 @@ feature "A user sees correct information for the current event and their role" d
     end
 
     visit root_path
-    click_on("View #{event_2.name}'s Guidelines")
+    click_on(event_2.name)
 
     within ".navbar" do
       expect(page).to have_link(event_2.name)
@@ -123,7 +123,7 @@ feature "A user sees correct information for the current event and their role" d
     expect(page).to have_link(event_1.name)
     expect(page).to have_link(event_2.name)
 
-    click_on "View #{event_2.name}'s Guidelines"
+    click_on event_2.name
     expect(current_path).to eq(event_path(event_2))
 
     within ".navbar" do
@@ -133,7 +133,7 @@ feature "A user sees correct information for the current event and their role" d
     end
 
     visit root_path
-    click_on "View #{event_1.name}'s Guidelines"
+    click_on event_1.name
     expect(current_path).to eq(event_path(event_1.slug))
 
     within ".navbar" do
@@ -151,7 +151,7 @@ feature "A user sees correct information for the current event and their role" d
 
     signin(reviewer_user.email, reviewer_user.password)
 
-    click_on "View #{event_1.name}'s Guidelines"
+    click_on event_1.name
 
     within ".navbar" do
       expect(page).to have_link(event_1.name)

--- a/spec/features/event_spec.rb
+++ b/spec/features/event_spec.rb
@@ -1,16 +1,16 @@
 require 'rails_helper'
 
 feature "Listing events for different roles" do
-  let(:event) { create(:event, state: 'open') }
+  let(:event) { create(:event, name: "Greens Event", state: 'open') }
   let!(:proposal) { create(:proposal, title: "A Proposal", abstract: 'foo', event: event) }
   let(:normal_user) { create(:user) }
   let(:organizer) { create(:user) }
 
   context "As a regular user" do
-    scenario "the user should see a link to the guidelines page for an event" do
+    scenario "the user should see a link to the CFP page for the event" do
       login_as(normal_user)
       visit events_path
-      expect(page).to have_link("View #{event.name}'s Guidelines", href: event_path(event))
+      expect(page).to have_link("Greens Event", href: event_path(event))
     end
   end
 
@@ -19,7 +19,7 @@ feature "Listing events for different roles" do
       create(:teammate, role: 'organizer', user: organizer)
       login_as(organizer)
       visit events_path
-      expect(page).to have_link("View #{event.name}'s Guidelines", href: event_path(event))
+      expect(page).to have_link("Greens Event", href: event_path(event))
     end
   end
 

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -10,13 +10,15 @@ describe Event do
       create(:event)
       expect(Event.live).to match_array(live_events)
     end
+  end
 
-    it "returns events in ascending cronological order" do
+  describe "closes_up" do
+    it "returns events in ascending cronological order by close date" do
       event1 = create(:event, closes_at: 1.week.from_now, state: 'open')
       event3 = create(:event, closes_at: 3.weeks.from_now, state: 'open')
       event2 = create(:event, closes_at: 2.weeks.from_now, state: 'open')
 
-      expect(Event.live).to eq([event1, event2, event3])
+      expect(Event.closes_up).to eq([event1, event2, event3])
     end
   end
 


### PR DESCRIPTION
- Don't show draft events.
- Get rid of guidelines link.
- Event link goes to CFP page for event.
