### PR TITLE
#130 Staff Invite Flow Changes

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,6 +18,7 @@ class ApplicationController < ActionController::Base
   helper_method :display_staff_subnav?
 
   before_action :current_event
+  before_action :configure_permitted_parameters, if: :devise_controller?
 
   layout 'application'
   decorates_assigned :event
@@ -52,6 +53,10 @@ class ApplicationController < ActionController::Base
 
   def pundit_user
     @pundit_user ||= CurrentEventContext.new(current_user, current_event)
+  end
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:pending_invite_email])
   end
 
   def event_staff?(current_event)

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -2,14 +2,11 @@ class ProfilesController < ApplicationController
   before_filter :require_user
 
   def edit
-    unless current_user.complete?
-      flash.now[:danger] = "Please make sure your name and email address are present and correct."
-    end
+    current_user.valid?
   end
 
   def update
     if current_user.update_attributes(user_params)
-      current_user.assign_open_invitations if session[:need_to_complete]
 
       if current_user.unconfirmed_email.present?
         flash[:danger] = I18n.t("devise.registrations.update_needs_confirmation")

--- a/app/controllers/teammates_controller.rb
+++ b/app/controllers/teammates_controller.rb
@@ -1,27 +1,21 @@
 class TeammatesController < ApplicationController
-  before_action :require_invitation
-  before_action :require_pending
-  rescue_from ActiveRecord::RecordNotFound, :with => :incorrect_token
+  before_action :require_pending_invitation, only: [:accept, :decline]
+  before_action :set_session_invite, only: [:accept]
+  before_action :require_user_for_invitation, only: [:accept]
+  before_action :require_non_teammate, only: [:accept]
 
   def accept
-    if !current_user
-      session[:pending_invite] = accept_teammate_url(@teammate_invitation.token)
-      flash[:info] = "Team invite to #{current_event.name} accepted!"
+    if @teammate_invitation.accept(current_user)
+      clear_session_invite
+
+      flash[:info] = "Congrats! You are now an official team member of #{current_event.name}! Before continuing, please take a moment to make sure your profile is complete."
+      session[:target] = event_staff_path(current_event)
+      redirect_to edit_profile_path
+
     else
-      if already_teammate?
-        flash[:danger] = "You are already a teammate for #{current_event.name}"
-        redirect_to event_staff_teammates_path(current_event)
-      else
-        @teammate_invitation.accept(current_user)
-        flash[:info] = "Team invite to #{current_event.name} accepted!"
-        if current_user.complete?
-          session.delete :pending_invite
-          flash[:info] = "Congrats! You are now an official team member of #{current_event.name}!"
-          redirect_to event_staff_path(current_event)
-        else
-          redirect_to edit_profile_path
-        end
-      end
+      flash[:danger] = "A problem occurred while accepting your invitation."
+      Rails.logger.error(@teammate_invitation.errors.full_messages.join(', '))
+      redirect_to root_url
     end
   end
 
@@ -34,25 +28,37 @@ class TeammatesController < ApplicationController
 
   private
 
-  def require_invitation
-    @teammate_invitation = Teammate.find_by!(token: params[:token])
-    set_current_event(@teammate_invitation.event_id)
-  end
-
-  def require_pending
-    redirect_to root_url unless @teammate_invitation.pending?
-  end
-
-  def already_teammate?
-    if current_event && current_user
-      Teammate.accepted.exists?(event_id: current_event.id, id: current_user.id)
+  def require_pending_invitation
+    @teammate_invitation = Teammate.pending.find_by(token: params[:token])
+    if @teammate_invitation
+      set_current_event(@teammate_invitation.event_id)
+    else
+      render :template => "errors/incorrect_token", :status => :not_found
     end
   end
 
-  protected
+  def set_session_invite
+    session[:pending_invite] = accept_teammate_url(@teammate_invitation.token)
+    session[:pending_invite_email] = @teammate_invitation.email
+  end
 
-  def incorrect_token
-    render :template => "errors/incorrect_token", :status => :not_found
+  def require_user_for_invitation
+    unless current_user
+      flash[:info] = "To accept your invitation, you must log in or create an account."
+      redirect_to new_user_session_url
+    end
+  end
+
+  def require_non_teammate
+    if current_user.staff_for?(current_event)
+      flash[:danger] = "You are already a team member of #{current_event.name}"
+      redirect_to event_staff_teammates_path(current_event)
+    end
+  end
+
+  def clear_session_invite
+    session.delete :pending_invite
+    session.delete :pending_invite_email
   end
 
 end

--- a/app/models/teammate.rb
+++ b/app/models/teammate.rb
@@ -30,13 +30,13 @@ class Teammate < ActiveRecord::Base
 
   def accept(user)
     self.user = user
-    self.accepted_at = Time.now
+    self.accepted_at = Time.current
     self.state = ACCEPTED
     save
   end
 
   def decline
-    self.declined_at = Time.now
+    self.declined_at = Time.current
     self.state = DECLINED
     save
   end
@@ -50,9 +50,9 @@ class Teammate < ActiveRecord::Base
   end
 
   def invite
-    self.token = Digest::SHA1.hexdigest(Time.now.to_s + email + rand(1000).to_s)
+    self.token = Digest::SHA1.hexdigest(Time.current.to_s + email + rand(1000).to_s)
     self.state = PENDING
-    self.invited_at = Time.now
+    self.invited_at = Time.current
     save
   end
 

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -13,6 +13,7 @@
           = f.input :email, required: true, autofocus: true, wrapper_html: {class: "col-sm-12"}
           = f.input :password, required: true, wrapper_html: {class: "col-sm-12"}, hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length)
           = f.input :password_confirmation, required: true, wrapper_html: {class: "col-sm-12"}
+          = f.hidden_field :pending_invite_email, value: session[:pending_invite_email]
 
           .form-group.col-sm-12
             = f.button :submit, "Sign up", class: "btn btn-success"

--- a/app/views/profiles/edit.html.haml
+++ b/app/views/profiles/edit.html.haml
@@ -12,10 +12,13 @@
           %i.fa.fa-user
           %h3 Your Profile
         .widget-content
+          - unless current_user.complete?
+            %p
+              Please make sure your name and email address are present and correct.
           %p
             This information will be
             %strong hidden
-            from the review committee, but will be shown on the program if your proposal is accepted.
+            from the review committee during the review process.
           .form-group
             = f.label :name
             = f.text_field :name, class: 'form-control', placeholder: 'Your name'

--- a/app/views/teammates/accept.html.haml
+++ b/app/views/teammates/accept.html.haml
@@ -1,9 +1,0 @@
-.row
-  .col-sm-12.text-center
-    %h2.margin-top= "Thanks for joining our team. To get started"
-    %br
-    = link_to "Create your Account", new_user_registration_path, class: "btn btn-primary btn-xlarge"
-    %br
-    %br
-    If you already have an account
-    = link_to "Log in", new_user_session_path

--- a/spec/features/staff/teammate_invitation_spec.rb
+++ b/spec/features/staff/teammate_invitation_spec.rb
@@ -1,53 +1,162 @@
 require 'rails_helper'
 
-feature "Teammate Invitations" do
+feature "Teammate Invitation received" do
   let(:event) { create(:event, name: "My Event") }
-  let!(:organizer_user) { create(:user) }
-  let!(:organizer_teammate) { create(:teammate, :organizer, user: organizer_user, event: invitation.event, state: Teammate::ACCEPTED) }
 
-  let(:invitation) { create(:teammate, :has_been_invited, event: event) }
+  let(:newguy_invitation) { create(:teammate, :has_been_invited, event: event, email: "new@per.son") }
+  let(:knownguy_invitation) { create(:teammate, :has_been_invited, event: event, email: "known@per.son") }
 
-  let!(:regular_user_1) { create(:user) }
-  let!(:regular_user_2) { create(:user) }
+  let!(:known_user) { create(:user, email: "known@per.son", password: "12345678") }
 
-  context "User has received a teammate invitation" do
-    it "can accept the invitation" do
-      visit accept_teammate_path(invitation.token)
+  describe "User not signed in" do
+    context "accepts invitation" do
 
-      expect(page).to have_content("Team invite to #{invitation.event.name} accepted!")
-      expect(page).to have_content("Thanks for joining our team.")
-      expect(page).to have_link("Log in")
-      expect(page).to have_link("Create your Account")
+      it "is redirected to the login page with a message" do
+        visit accept_teammate_path(knownguy_invitation.token)
+        expect(page).to have_content("To accept your invitation, you must log in or create an account.")
+        expect(current_path).to eq(new_user_session_path)
+      end
+
+      describe "signs in to complete the process" do
+        before(:each) do
+          visit accept_teammate_path(knownguy_invitation.token)
+        end
+
+        it "can signin with a regular account" do
+          signin("known@per.son", "12345678")
+          expect(page).to have_content("Congrats! You are now an official team member of My Event!")
+        end
+
+        it "can signin with a twitter oauth account" do
+          known_user.provider = OmniAuth.config.mock_auth[:twitter][:provider]
+          known_user.uid = OmniAuth.config.mock_auth[:twitter][:uid]
+          known_user.save
+
+          click_link "Sign in with Twitter"
+          expect(page).to have_content("Congrats! You are now an official team member of My Event!")
+        end
+
+        it "can signin with a github oauth account" do
+          known_user.provider = OmniAuth.config.mock_auth[:github][:provider]
+          known_user.uid = OmniAuth.config.mock_auth[:github][:uid]
+          known_user.save
+
+          click_link "Sign in with Github"
+          expect(page).to have_content("Congrats! You are now an official team member of My Event!")
+        end
+
+        it "is redirected to profile page after signin" do
+          signin("known@per.son", "12345678")
+          expect(current_path).to eq(edit_profile_path)
+          expect(page).to have_content("Congrats! You are now an official team member of My Event!")
+        end
+      end
+
+      describe "creates an account to complete the process" do
+        before(:each) do
+          visit accept_teammate_path(newguy_invitation.token)
+        end
+
+        it "can use a regular account" do
+          click_link "Sign up"
+          sign_up_with("new@per.son", "apples", "apples")
+          expect(page).to have_content("Congrats! You are now an official team member of My Event!")
+        end
+
+        it "can use a twitter oauth account" do
+          click_link "Sign up"
+          click_link "Sign in with Twitter"
+          expect(page).to have_content("Congrats! You are now an official team member of My Event!")
+        end
+
+        it "can use a github oauth account" do
+          click_link "Sign up"
+          click_link "Sign in with Github"
+          expect(page).to have_content("Congrats! You are now an official team member of My Event!")
+        end
+
+        it "must complete profile if name missing" do
+          click_link "Sign up"
+          sign_up_with("new@per.son", "apples", "apples")
+          expect(page).to have_content("Before continuing, please take a moment to make sure your profile is complete.")
+          expect(current_path).to eq(edit_profile_path)
+        end
+
+        it "must complete profile if name missing from oauth hash" do
+          OmniAuth.config.mock_auth[:twitter][:info].delete(:name)
+          click_link "Sign in with Twitter"
+          expect(page).to have_content("Before continuing, please take a moment to make sure your profile is complete.")
+          expect(current_path).to eq(edit_profile_path)
+        end
+
+        it "is redirected to team page after completing profile" do
+          click_link "Sign up"
+          sign_up_with("new@per.son", "apples", "apples")
+          fill_in "Name", with: "A. Paul"
+          click_button "Save"
+          expect(current_path).to eq(event_staff_path(event))
+        end
+
+        it "must confirm email first if new account email doesn't match invitation email" do
+          click_link "Sign up"
+          sign_up_with("new57@per.son", "apples", "apples")
+          expect(page).to have_content("A message with a confirmation link has been sent to your email address")
+          expect(current_path).to eq(events_path)
+        end
+
+        it "can complete process after email is confirmed" do
+          click_link "Sign up"
+          sign_up_with("new57@per.son", "apples", "apples")
+          user = User.find_by!(email: "new57@per.son")
+          visit user_confirmation_path(confirmation_token: user.confirmation_token)
+          signin("new57@per.son", "apples")
+
+          expect(page).to have_content("Congrats! You are now an official team member of My Event! Before continuing, please take a moment to make sure your profile is complete.")
+          expect(current_path).to eq(edit_profile_path)
+
+          fill_in "Name", with: "A. Paul"
+          click_button "Save"
+          expect(current_path).to eq(event_staff_path(event))
+        end
+
+        it "will skip email confirmation if new account email matches invitation email" do
+          click_link "Sign up"
+          sign_up_with("new@per.son", "apples", "apples")
+          expect(page).to_not have_content("A message with a confirmation link has been sent to your email address")
+        end
+      end
     end
 
-    it "a logged in user can accept an invitation" do
-      login_as(regular_user_1)
+    it "can decline the invitiation" do
+      visit decline_teammate_path(newguy_invitation.token)
+      expect(page).to have_content("You declined the invitation to #{newguy_invitation.event.name}.")
+    end
+  end
 
-      visit accept_teammate_path(invitation.token)
+  context "User who is signed in" do
+    before(:each) do
+      signin("known@per.son", "12345678")
+    end
 
-      expect(page).to have_content("Congrats! You are now an official team member of #{invitation.event.name}!")
+    context "accepts invitation" do
+      it "instantly becomes a teammate and is redirected to the team page" do
+        visit accept_teammate_path(knownguy_invitation.token)
+        expect(page).to have_content("Congrats! You are now an official team member of #{knownguy_invitation.event.name}!")
+      end
     end
 
     it "can decline the invitation" do
-      visit decline_teammate_path(invitation.token)
-
-      expect(page).to have_content("You declined the invitation to #{invitation.event.name}.")
-    end
-
-    it "a logged in user can decline an invitation to be a teammate" do
-      login_as(regular_user_2)
-
-      visit decline_teammate_path(invitation.token)
-
-      expect(page).to have_content("You declined the invitation to #{invitation.event.name}.")
-    end
-
-    context "User receives incorrect or missing link in teammate invitation email" do
-      it "shows a custom 404 error" do
-        visit accept_teammate_path(invitation.token + "bananas")
-        expect(page).to have_text("Oh My. A 404 error. Your confirmation invite link is missing or wrong.")
-        expect(page).to have_text("Events")
-      end
+      visit decline_teammate_path(knownguy_invitation.token)
+      expect(page).to have_content("You declined the invitation to #{newguy_invitation.event.name}.")
     end
   end
+
+  context "Token is invalid or invitation can't be found" do
+    it "shows a custom 404 error" do
+      visit accept_teammate_path(newguy_invitation.token + "bananas")
+      expect(page).to have_text("Oh My. A 404 error. Your confirmation invite link is missing or wrong.")
+      expect(page).to have_text("Events")
+    end
+  end
+
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -53,6 +53,7 @@ RSpec.configure do |config|
   end
 
   config.before(:each) do |example|
+    init_mock_omniauth
     DatabaseCleaner.strategy= example.metadata[:js] ? :truncation : :transaction
     DatabaseCleaner.start
   end

--- a/spec/support/omniauth.rb
+++ b/spec/support/omniauth.rb
@@ -1,19 +1,22 @@
 OmniAuth.config.test_mode = true
-OmniAuth.config.mock_auth[:twitter] = OmniAuth::AuthHash.new({
-  provider: 'twitter',
-  uid: 'test_omni_user',
-  info: {
-    nickname: 'test_omni_user',
-    name: 'Test User'
-  }
-})
 
-OmniAuth.config.mock_auth[:github] = OmniAuth::AuthHash.new({
-  provider: 'github',
-  uid: 'test_omni_user',
-  info: {
-    email: 'test@omniuser.com',
-    nickname: 'test_omni_user',
-    name: 'Test User'
-  }
-})
+def init_mock_omniauth
+  OmniAuth.config.mock_auth[:twitter] = OmniAuth::AuthHash.new({
+    provider: 'twitter',
+    uid: 'test_omni_user',
+    info: {
+      nickname: 'test_omni_user',
+      name: 'Test User'
+    }
+  })
+
+  OmniAuth.config.mock_auth[:github] = OmniAuth::AuthHash.new({
+    provider: 'github',
+    uid: 'test_omni_user',
+    info: {
+      email: 'test@omniuser.com',
+      nickname: 'test_omni_user',
+      name: 'Test User'
+    }
+  })
+end


### PR DESCRIPTION
- When invitee creates new account, prepopulate email address with invite
  email and skip email confirmation step.
- When invitee creates new account via OAuth, give priority to invite email over
  the auth_hash email when creating new user record.
- Ensure accepting invite has to happen only once.
- Teammate accept page now unused.
