### PR TITLE
#134 Firming up review flow blindness

### DIFF
--- a/app/controllers/staff/program_controller.rb
+++ b/app/controllers/staff/program_controller.rb
@@ -1,7 +1,7 @@
 class Staff::ProgramController < Staff::ApplicationController
   def show
     accepted_proposals =
-      @event.proposals.for_state(Proposal::State::ACCEPTED)
+        @event.proposals.for_state(Proposal::State::ACCEPTED)
 
     waitlisted_proposals = @event.proposals.for_state(Proposal::State::WAITLISTED)
 

--- a/app/views/staff/program/show.html.haml
+++ b/app/views/staff/program/show.html.haml
@@ -3,8 +3,6 @@
     .col-md-12
       .page-header.clearfix
         .btn-nav.pull-right
-          =link_to new_event_staff_proposal_path, class: "btn btn-info" do
-            Create Accepted Proposal
           =link_to event_staff_program_path(format: "json"), id: "download_link", class: "btn btn-info" do
             %span.glyphicon.glyphicon-download-alt
             Download as JSON

--- a/app/views/staff/proposal_reviews/show.html.haml
+++ b/app/views/staff/proposal_reviews/show.html.haml
@@ -36,9 +36,6 @@
     .proposal-info-bar
       .proposal-meta.proposal-description
         .proposal-meta-item
-          %strong #{ 'Speaker'.pluralize(proposal.speakers.count) }:
-          %span= proposal.speakers.collect { |speaker| speaker.name }.join(', ')
-        .proposal-meta-item
           %strong Format:
           %span #{proposal.session_format.name}
 

--- a/spec/features/staff/teammate_invitation_spec.rb
+++ b/spec/features/staff/teammate_invitation_spec.rb
@@ -17,7 +17,7 @@ feature "Teammate Invitations" do
       expect(page).to have_content("Team invite to #{invitation.event.name} accepted!")
       expect(page).to have_content("Thanks for joining our team.")
       expect(page).to have_link("Log in")
-      expect(page).to have_button("Create your Account")
+      expect(page).to have_link("Create your Account")
     end
 
     it "a logged in user can accept an invitation" do


### PR DESCRIPTION
- Removed speaker names being displayed in upper-left on proposal review page
- Temporarily disabled any routes to do with legacy organizer proposal actions.
- Temporarily nerfed program index to be void of proposal data.
- Removed deprecated Create Approved Proposal button.
