### PR TITLE
#144 Obfuscates email

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem 'zeroclipboard-rails'
 gem 'responders', '~> 2.0'
 gem 'pundit'
 gem 'faker'
+gem 'actionview-encoded_mail_to'
 
 group :production do
   gem 'rails_12factor'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,6 +30,8 @@ GEM
       erubis (~> 2.7.0)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    actionview-encoded_mail_to (1.0.7)
+      rails
     active_model_serializers (0.8.3)
       activemodel (>= 3.0)
     activejob (4.2.5)
@@ -114,7 +116,7 @@ GEM
     factory_girl_rails (4.5.0)
       factory_girl (~> 4.5.0)
       railties (>= 3.0.0)
-    faker (1.6.1)
+    faker (1.6.6)
       i18n (~> 0.5)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
@@ -350,6 +352,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  actionview-encoded_mail_to
   active_model_serializers (~> 0.8.1)
   annotate
   better_errors
@@ -404,6 +407,9 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
   zeroclipboard-rails
+
+RUBY VERSION
+   ruby 2.3.0p0
 
 BUNDLED WITH
    1.12.5

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -14,7 +14,7 @@
         - if event.contact_email?
           %span.event-meta
             %i.fa.fa-fw.fa-envelope
-            = mail_to(event.contact_email)
+            = mail_to(current_event.contact_email, current_event.contact_email, encode: "javascript")
 
 .row
   .col-md-12

--- a/app/views/layouts/_event_footer.html.haml
+++ b/app/views/layouts/_event_footer.html.haml
@@ -10,7 +10,7 @@
                 %span.event-meta
                   Contact:
                   %i.fa.fa-fw.fa-envelope
-                  = mail_to(current_event.contact_email)
+                  = mail_to(current_event.contact_email, current_event.contact_email, encode: "javascript")
           - else
             = link_to "#{Rails.application.class.parent_name}", events_path
         .col-md-4.text-right


### PR DESCRIPTION
Encrypts email in footer and info bar on event show page.

@mghaught not sure if this is the way you had in mind, but it seems to be working when I inspect the email on the page and look at the script tag it's generating.
