### PR TITLE
#135 Organizer CRUD for speakers

### DIFF
--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -32,7 +32,7 @@ class ProposalsController < ApplicationController
   end
 
   def set_confirmed
-    @proposal.update(confirmed_at: DateTime.now,
+    @proposal.update(confirmed_at: DateTime.current,
                      confirmation_notes: params[:confirmation_notes])
     redirect_to confirm_event_proposal_url(slug: @proposal.event.slug, uuid: @proposal),
       flash: { success: 'Thank you for confirming your participation' }
@@ -61,7 +61,7 @@ class ProposalsController < ApplicationController
       flash[:info] = setup_flash_message
       redirect_to event_proposal_url(event_slug: @event.slug, uuid: @proposal)
     else
-      flash[:danger] = 'There was a problem saving your proposal.'
+      flash[:danger] = "There was a problem saving your proposal."
       render :new
     end
   end
@@ -80,12 +80,12 @@ class ProposalsController < ApplicationController
 
   def update
     if params[:confirm]
-      @proposal.update(confirmed_at: DateTime.now)
-      redirect_to event_event_proposals_url(slug: @event.slug, uuid: @proposal), flash: { success: 'Thank you for confirming your participation' }
+      @proposal.update(confirmed_at: DateTime.current)
+      redirect_to event_event_proposals_url(slug: @event.slug, uuid: @proposal), flash: { success: "Thank you for confirming your participation" }
     elsif @proposal.update_and_send_notifications(proposal_params)
       redirect_to event_proposal_url(event_slug: @event.slug, uuid: @proposal)
     else
-      flash[:danger] = 'There was a problem saving your proposal.'
+      flash[:danger] = "There was a problem saving your proposal."
       render :edit
     end
   end
@@ -113,14 +113,14 @@ class ProposalsController < ApplicationController
   def require_invite_or_speaker
     unless @proposal.has_speaker?(current_user) || @proposal.has_invited?(current_user)
       redirect_to root_path
-      flash[:danger] = 'You are not an invited speaker for the proposal you are trying to access.'
+      flash[:danger] = "You are not an invited speaker for the proposal you are trying to access."
     end
   end
 
   def require_speaker
     unless @proposal.has_speaker?(current_user)
       redirect_to root_path
-      flash[:danger] = 'You are not a listed speaker for the proposal you are trying to access.'
+      flash[:danger] = "You are not a listed speaker for the proposal you are trying to access."
     end
   end
 

--- a/app/controllers/staff/proposals_controller.rb
+++ b/app/controllers/staff/proposals_controller.rb
@@ -1,6 +1,6 @@
 class Staff::ProposalsController < Staff::ApplicationController
-  before_filter :require_proposal, except: [:index, :new, :create, :edit_all]
-  before_filter :prevent_self, only: [:show, :update]
+  before_action :require_proposal, except: [:index, :new, :create, :edit_all]
+  before_action :prevent_self, only: [:show, :update]
 
   decorates_assigned :proposal, with: Staff::ProposalDecorator
 
@@ -22,7 +22,7 @@ class Staff::ProposalsController < Staff::ApplicationController
   def index
     proposals = @event.proposals.includes(:event, :review_taggings, :proposal_taggings, :ratings, {speakers: :user}).load
 
-    session[:prev_page] = {name: 'Proposals', path: event_staff_proposals_path}
+    session[:prev_page] = {name: "Proposals", path: event_staff_proposals_path}
 
     taggings_count = Tagging.count_by_tag(@event)
 
@@ -58,10 +58,10 @@ class Staff::ProposalsController < Staff::ApplicationController
 
   def update
     if @proposal.update_without_touching_updated_by_speaker_at(proposal_params)
-      flash[:info] = 'Proposal Updated'
-      redirect_to event_staff_proposal_path(@event, @proposal)
+      flash[:info] = "Proposal Updated"
+      redirect_to event_staff_proposal_url(@event, @proposal)
     else
-      flash[:danger] = 'There was a problem saving your proposal; please review the form for issues and try again.'
+      flash[:danger] = "There was a problem saving your proposal; please review the form for issues and try again."
       render :edit
     end
   end
@@ -82,10 +82,10 @@ class Staff::ProposalsController < Staff::ApplicationController
     altered_params = proposal_params.merge!("state" => "accepted", "confirmed_at" => DateTime.now)
     @proposal = @event.proposals.new(altered_params)
     if @proposal.save
-      flash[:success] = 'Proposal Added'
+      flash[:success] = "Proposal Added"
       redirect_to event_staff_program_url(@event)
     else
-      flash.now[:danger] = 'There was a problem saving your proposal; please review the form for issues and try again.'
+      flash.now[:danger] = "There was a problem saving your proposal; please review the form for issues and try again."
       render :new
     end
   end

--- a/app/decorators/speaker_decorator.rb
+++ b/app/decorators/speaker_decorator.rb
@@ -1,6 +1,7 @@
 class SpeakerDecorator < ApplicationDecorator
   delegate_all
   decorates_association :proposals
+  decorates_association :program_sessions
 
   def gravatar
     image_url =
@@ -14,7 +15,7 @@ class SpeakerDecorator < ApplicationDecorator
   end
 
   def bio
-    speaker.bio.present? ? speaker.bio : speaker.user.bio
+    object.bio.present? ? object.bio : object.user.try(:bio)
   end
 
   def delete_button

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -10,7 +10,7 @@ class Invitation < ActiveRecord::Base
     transaction do
       self.user = user
       self.state = State::ACCEPTED
-      proposal.speakers.create(user: user, event: proposal.event)
+      proposal.speakers.create(user: user, event: proposal.event, skip_name_email_validation: true)
       save
     end
   end

--- a/app/models/program_session.rb
+++ b/app/models/program_session.rb
@@ -36,6 +36,10 @@ class ProgramSession < ActiveRecord::Base
       ps
     end
   end
+
+  def multiple_speakers?
+    speakers.count > 1
+  end
 end
 
 # == Schema Information

--- a/app/models/speaker.rb
+++ b/app/models/speaker.rb
@@ -5,12 +5,18 @@ class Speaker < ActiveRecord::Base
   belongs_to :program_session
 
   has_many :proposals, through: :user
-  has_many :program_sessions, through: :user
+  has_many :program_sessions
 
   serialize :info, Hash
 
-  validates :user, :event, presence: true
+  validates :event, presence: true
   validates :bio, length: {maximum: 500}
+  validates :name, :email, presence: true, unless: :skip_name_email_validation
+  validates_format_of :email, with: Devise.email_regexp
+
+  attr_accessor :skip_name_email_validation
+
+  scope :in_program, -> { Speaker.where("program_session_id IS NOT NULL") }
 
   def name
     speaker_name.present? ? speaker_name : user.try(:name)

--- a/app/policies/speaker_policy.rb
+++ b/app/policies/speaker_policy.rb
@@ -1,0 +1,15 @@
+class SpeakerPolicy < ApplicationPolicy
+
+  def create?
+    @user.organizer_for_event?(current_event)
+  end
+
+  def update?
+    @user.organizer_for_event?(current_event)
+  end
+
+  def destroy?
+    @user.organizer_for_event?(current_event)
+  end
+
+end

--- a/app/views/proposals/index.html.haml
+++ b/app/views/proposals/index.html.haml
@@ -89,4 +89,4 @@
                         = proposal.public_state(small: true)
                       .proposal-meta
                         %i.fa.fa-fw.fa-comments
-                        = pluralize(proposal.public_comments.count, 'comment')    
+                        = pluralize(proposal.public_comments.count, 'comment')

--- a/app/views/staff/speakers/edit.html.haml
+++ b/app/views/staff/speakers/edit.html.haml
@@ -1,18 +1,28 @@
-= link_to(event_staff_proposal_path(speaker.proposal.event, speaker.proposal),
-              class: "btn btn-primary", id: "back") do
+.row
+  .col-md-12
+    .page-header.clearfix
+      .btn-nav.pull-right
+        =  link_to("« Return to Speaker List", event_staff_speakers_path(current_event), class: "btn btn-primary", id: "back")
 
-  &laquo; Return to Proposal
+      %h1 Edit Speaker
 
-%p
-= simple_form_for speaker, url: [ event, :staff, speaker ] do |f|
-  .row
-    %fieldset.col-md-4
-      = f.input :speaker_name, placeholder: speaker.user.try(:name)
-      = f.input :speaker_email, placeholder: speaker.user.try(:email)
-      %p
-      = f.input :bio, maxlength: :lookup,
-        placeholder: 'Bio for speaker for the event program'
+.row
+  .col-md-12
+    %p
+    = simple_form_for speaker, url: [ event, :staff, speaker ] do |f|
+      .row
+        %fieldset.col-md-6
+          = f.label "Name"
+          = f.text_field :speaker_name, class: "form-control", placeholder: @speaker.name
+          %br
+          = f.label "Email"
+          = f.text_field :speaker_email, class: "form-control", placeholder: @speaker.email
+          %br
+          = f.label :bio
+          = f.text_area :bio, class: "form-control", value: speaker.bio,
+          placeholder: "Bio for the event program", rows: 7, maxlength: 500
+          %p.help-block Bio is limited to 500 characters.
 
-  .row.col-md-12.form-submit
-    %button.pull-right.btn.btn-success{:type => "submit"} Save
-
+      .row.col-md-12.form-submit.btn-toolbar
+        = link_to("Cancel", event_staff_speakers_path(current_event), class: "button pull-right btn btn-danger")
+        %button.pull-right.btn.btn-success{:type => "submit"} Save

--- a/app/views/staff/speakers/index.html.haml
+++ b/app/views/staff/speakers/index.html.haml
@@ -2,10 +2,10 @@
   .col-md-12
     .page-header.clearfix
       .btn-nav.pull-right
-        =link_to(event_staff_path(event), class: "btn btn-primary") do
+        = link_to event_staff_path(event), class: "btn btn-primary" do
           &laquo; Return to Event
       %h1
-        = event
+        = current_event
         Speakers
 
 .row
@@ -16,17 +16,26 @@
           %th
           %th
           %th
-          %th
         %tr
           %th Name
           %th Email
-          %th Proposal Title
-          %th Proposal Status
+          %th Program Session Title
+          %th Actions
       %tbody
-        - proposals.each do |proposal|
-          - proposal.speakers.each do |speaker|
-            %tr
-              %td=link_to speaker.name, edit_profile_event_staff_speaker_path(event, speaker)
-              %td= speaker.email
-              %td= link_to proposal.title, event_staff_proposal_path(event, proposal)
-              %td= proposal.state_label(small: true)
+        - @program_speakers.each do |speaker|
+          %tr{ id: "speaker-#{speaker.id}" }
+            %td= speaker.name
+            %td= speaker.email
+            %td= link_to speaker.program_session.title, "#" # should this go to a program session show page?
+            %td{ id: "speaker-action-buttons-#{speaker.id}" }
+              %span>
+                = link_to "Edit", edit_event_staff_speaker_path(current_event, speaker), class: "btn btn-primary btn-xs"
+              %span>
+                = link_to "Add Speaker", new_event_staff_program_session_speaker_path(current_event, speaker.program_session), class: "btn btn-primary btn-xs"
+              %span>
+                - if speaker.program_session.multiple_speakers?
+                  = link_to "Remove",
+                    event_staff_speaker_path(current_event, speaker),
+                    method: :delete,
+                    data: { confirm: "Are you sure you want to remove this speaker?" },
+                    class: "btn btn-danger btn-xs"

--- a/app/views/staff/speakers/new.html.haml
+++ b/app/views/staff/speakers/new.html.haml
@@ -3,25 +3,26 @@
     .col-md-12
       .page-header.clearfix
         .btn-nav.pull-right
-          =  link_to("« Return to Proposal", event_staff_proposal_path(uuid: @proposal.uuid), class: "btn btn-primary", id: "back")
+          = link_to("« Return to Speaker List", event_staff_speakers_path, class: "btn btn-primary", id: "back")
 
         %h1 New Speaker
 
   .row
     .col-md-12
-      = form_for @speaker, url: [ event, :staff, @proposal, @speaker ], html: {role: 'form'} do  |f|
+      = form_for @speaker, url: [ event, :staff, @program_session, @speaker ], html: {role: "form"} do  |f|
         .row
-          %fieldset.col-md-4
+          %fieldset.col-md-6
+            = f.label "Name"
+            = f.text_field :speaker_name, class: "form-control"
+            %br
             = f.label "Email"
-            = f.text_field :speaker_email, class: "form-control", placeholder: @speaker.email
+            = f.text_field :speaker_email, class: "form-control"
             %br
             = f.label :bio
-            = f.text_area :bio, class: 'form-control', value: speaker.bio,
-            placeholder: 'Bio for the event program.', rows: 7, maxlength: 500
+            = f.text_area :bio, class: "form-control", value: speaker.bio,
+            placeholder: "Bio for the event program", rows: 7, maxlength: 500
             %p.help-block Bio is limited to 500 characters.
 
-
-        .row.col-md-12.form-submit
+        .row.col-md-12.form-submit.btn-toolbar
+          = link_to("Cancel", event_staff_speakers_path, class: "button pull-right btn btn-danger")
           %button.pull-right.btn.btn-success{:type => "submit"} Save
-
-

--- a/app/views/staff/speakers/show.html.haml
+++ b/app/views/staff/speakers/show.html.haml
@@ -3,11 +3,7 @@
     .col-md-12
       .page-header.clearfix
         .btn-nav.pull-right
-          = link_to(event_staff_proposal_path(speaker.proposal.event, speaker.proposal), class: "btn btn-primary") do
-            &laquo; Return to Proposal
-          = link_to(edit_event_staff_speaker_path, class: "btn btn-primary") do
-            Edit Speaker
-          = speaker.delete_button
+          =  link_to("« Return to Speaker List", event_staff_speakers_path, class: "btn btn-primary", id: "back")
 
         %h1 Speaker Profile
 
@@ -18,9 +14,11 @@
           id: 'speaker_gravatar')
         %br
         %b Name:
+        %br
         = speaker.name
       %p
         %b Email:
+        %br
         = mail_to(speaker.email)
       %p
         %b Bio:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
 
   root 'home#show'
-  devise_for :users, controllers: { omniauth_callbacks: "users/omniauth_callbacks" }
+  devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks' }
 
   get '/profile' => 'profiles#edit', as: :edit_profile
   patch '/profile' => 'profiles#update'
@@ -49,11 +49,18 @@ Rails.application.routes.draw do
 
       get '/speaker-emails' => 'events#speaker_emails', as: :speaker_email_notifications
 
-      resources :teammates, path: "team"
+      resources :teammates, path: 'team'
 
       controller :program do
         get 'program' => 'program#show'
         get 'program-selection' => 'program#selection'
+      end
+
+      scope path: 'program' do
+        resources :speakers, only: [:index, :show, :edit, :update, :destroy]
+        resources :program_sessions do
+          resources :speakers, only: [:new, :create]
+        end
       end
 
       resources :rooms, only: [:create, :update, :destroy]
@@ -74,13 +81,6 @@ Rails.application.routes.draw do
       controller :speakers do
         get :speaker_emails, action: :emails #returns json of speaker emails
       end
-
-      resources :speakers, only: [:index, :show, :edit, :update, :destroy] do
-        member do
-          get :profile, to: "profiles#edit", as: :edit_profile
-          patch :profile, to: "profiles#update", as: :update_profile
-        end
-      end
     end
   end
 
@@ -90,8 +90,8 @@ Rails.application.routes.draw do
   resources :speakers, only: [:destroy]
   resources :events, only: [:index]
 
-  get "teammates/:token/accept", :to => "teammates#accept", as: :accept_teammate
-  get "teammates/:token/decline", :to => "teammates#decline", as: :decline_teammate
+  get 'teammates/:token/accept', :to => 'teammates#accept', as: :accept_teammate
+  get 'teammates/:token/decline', :to => 'teammates#decline', as: :decline_teammate
 
   resources :invitations, only: [:show, :create, :destroy], param: :invitation_slug do
     member do
@@ -110,9 +110,9 @@ Rails.application.routes.draw do
     resources :users
   end
 
-  get "/current-styleguide", :to => "pages#current_styleguide"
-  get "/404", :to => "errors#not_found"
-  get "/422", :to => "errors#unacceptable"
-  get "/500", :to => "errors#internal_error"
+  get '/current-styleguide', :to => 'pages#current_styleguide'
+  get '/404', :to => 'errors#not_found'
+  get '/422', :to => 'errors#unacceptable'
+  get '/500', :to => 'errors#internal_error'
 
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -20,7 +20,6 @@ def run
 
 end
 
-
 def create_seed_data
 
   pwd = "userpass"
@@ -59,7 +58,7 @@ If your talk is about seed data in Rails apps, we want to hear about it!
 
   seed_event = Event.create(name: "SeedConf",
                             slug: "seedconf",
-                            url: "http://nativeseed.info/",
+                            url: Faker::Internet.url,
                             contact_email: "info@seed.event",
                             closes_at: 6.months.from_now,
                             state: "open",
@@ -94,59 +93,59 @@ If your talk is about seed data in Rails apps, we want to hear about it!
   # Proposals - there are no proposals that are either fully "accepted" or offically "not accepted"
   submitted_proposal_1 = seed_event.proposals.create(event: seed_event,
                                                      uuid: "abc123",
-                                                     title: "Honey Bees",
-                                                     abstract: "We will discuss the vital importance of pollinators and how we can help them thrive.",
-                                                     details: "Why we need pollinators, what plants they love most, basics of how to start your own hive.",
-                                                     pitch: "Learning to be stewards for our insect friends is essential to keeping some of our favorite foods around!",
+                                                     title: Faker::Superhero.name,
+                                                     abstract: Faker::Hipster.sentence,
+                                                     details: Faker::Hacker.say_something_smart,
+                                                     pitch: Faker::Superhero.power,
                                                      session_format: long_session,
                                                      track: track_1)
 
   submitted_proposal_2 = seed_event.proposals.create(event: seed_event,
                                                      uuid: "def456",
-                                                     title: "Coffee Talk",
-                                                     abstract: "We go over what makes a great cup of coffee as well as different methods of preparation.",
-                                                     details: "We will talk about the coffee plant itself, the roasting process, and prepare the same beans in a variety of different ways to compare the flavor and nuances.",
-                                                     pitch: "You need coffee to live happily, why not be drinking the best tasting versions of your favorite drug?",
+                                                     title: Faker::Superhero.name,
+                                                     abstract: Faker::Hipster.sentence,
+                                                     details: Faker::Hacker.say_something_smart,
+                                                     pitch: Faker::Superhero.power,
                                                      session_format: long_session,
                                                      track: track_2)
 
   soft_waitlisted_proposal = seed_event.proposals.create(event: seed_event,
                                                          state: "soft waitlisted",
                                                          uuid: "jkl012",
-                                                         title: "Javascript for Dummies",
-                                                         abstract: "This talk is a basic introduction to Javascript and how to use it effectively.",
-                                                         details: "Discussion will include a bit about the history of JS and some high level topics. From there we will learn enough basics to build a simple game together!",
-                                                         pitch: "You + Javascript = Besties for Life!!",
+                                                         title: Faker::Superhero.name,
+                                                         abstract: Faker::Hipster.sentence,
+                                                         details: Faker::Hacker.say_something_smart,
+                                                         pitch: Faker::Superhero.power,
                                                          session_format: short_session,
                                                          track: track_3)
 
   soft_accepted_proposal = seed_event.proposals.create(event: seed_event,
                                                        state: "soft accepted",
                                                        uuid: "mno345",
-                                                       title: "Vegan Ice Cream",
-                                                       abstract: "This is a hands on class where we will make some delicious dairy-and-egg-free concoctions!",
-                                                       details: "Participants will learn the basics of how to make a healthy animal-free ice cream as well as how to come up with amazing flavor combinations.",
-                                                       pitch: "Who doesn't love ice cream?",
+                                                       title: Faker::Superhero.name,
+                                                       abstract: Faker::Hipster.sentence,
+                                                       details: Faker::Hacker.say_something_smart,
+                                                       pitch: Faker::Superhero.power,
                                                        session_format: internal_session,
                                                        track: track_1)
 
   soft_rejected_proposal = seed_event.proposals.create(event: seed_event,
                                                        state: "soft rejected",
                                                        uuid: "xyz999",
-                                                       title: "DIY Unicorn Hat in 30 minutes",
-                                                       abstract: "You need to keep your head warm, why not do it with style?",
-                                                       details: "It's arts and crafts time! Learn how to make the hat of your dreams with the things already lying around your house.",
-                                                       pitch: "Have you really lived this long without a unicorn hat?",
+                                                       title: Faker::Superhero.name,
+                                                       abstract: Faker::Hipster.sentence,
+                                                       details: Faker::Hacker.say_something_smart,
+                                                       pitch: Faker::Superhero.power,
                                                        session_format: short_session,
                                                        track: track_2)
 
   withdrawn_proposal = seed_event.proposals.create(event: seed_event,
                                                    state: "withdrawn",
                                                    uuid: "pqr678",
-                                                   title: "Mystical Vortices",
-                                                   abstract: "Learn spiritual energy technics to help cure what ails you.",
-                                                   details: "We will enter into the portable vortex I carry in my bag at all times and explore the realms of the unreal.",
-                                                   pitch: "Uh, I said VORTICES - what more motivation for coming do you need??",
+                                                   title: Faker::Superhero.name,
+                                                   abstract: Faker::Hipster.sentence,
+                                                   details: Faker::Hacker.say_something_smart,
+                                                   pitch: Faker::Superhero.power,
                                                    session_format: lightning_talk,
                                                    track: track_1)
 
@@ -217,9 +216,50 @@ If your talk is about seed data in Rails apps, we want to hear about it!
                                    body: "Uhhhh... is this for real? I can't decide if this is amazing or insane.",
                                    type: "InternalComment")
 
+  # Program Sessions
+  accepted_proposal_1 = seed_event.proposals.create(event: seed_event,
+                                                    uuid: "xoxoxo",
+                                                    state: "accepted",
+                                                    title: Faker::Superhero.name,
+                                                    abstract: Faker::Hipster.sentence,
+                                                    details: Faker::Hacker.say_something_smart,
+                                                    pitch: Faker::Superhero.power,
+                                                    session_format: long_session,
+                                                    track: track_1,
+                                                    confirmed_at: Time.current)
+
+  accepted_proposal_2 = seed_event.proposals.create(event: seed_event,
+                                                    uuid: "oxoxox",
+                                                    state: "accepted",
+                                                    title: Faker::Superhero.name,
+                                                    abstract: Faker::Hipster.sentence,
+                                                    details: Faker::Hacker.say_something_smart,
+                                                    pitch: Faker::Superhero.power,
+                                                    session_format: long_session,
+                                                    track: track_3,
+                                                    confirmed_at: Time.current)
+
+  program_session_1 = seed_event.program_sessions.create(event: seed_event,
+                                                         proposal: accepted_proposal_1,
+                                                         title: accepted_proposal_1.title,
+                                                         abstract: accepted_proposal_1.abstract,
+                                                         track: accepted_proposal_1.track,
+                                                         session_format: accepted_proposal_1.session_format)
+
+  program_session_2 = seed_event.program_sessions.create(event: seed_event,
+                                                         proposal: accepted_proposal_2,
+                                                         title: accepted_proposal_2.title,
+                                                         abstract: accepted_proposal_2.abstract,
+                                                         track: accepted_proposal_2.track,
+                                                         session_format: accepted_proposal_2.session_format)
+
+  accepted_proposal_1.speakers.create(speaker_name: speaker_4.name, speaker_email: speaker_4.email, user: speaker_4, program_session: program_session_1, event: seed_event)
+  accepted_proposal_1.speakers.create(speaker_name: speaker_5.name, speaker_email: speaker_5.email, user: speaker_5, program_session: program_session_1, event: seed_event)
+  accepted_proposal_2.speakers.create(speaker_name: speaker_2.name, speaker_email: speaker_2.email, user: speaker_2, program_session: program_session_2, event: seed_event)
 
   ### SapphireConf -- this is an event in the early set-up/draft stage
   sapphire_start_date = 10.months.from_now
+  pwd = "userpass"
 
   # Core Event Info
   sapphire_guidelines = %Q[
@@ -236,7 +276,7 @@ If you are on the cutting edge with savvy Sapphire skills, we want you!
 
   sapphire_event = Event.create(name: "SapphireConf",
                                 slug: "sapphireconf",
-                                url: "https://en.wikipedia.org/wiki/Sapphire",
+                                url: Faker::Internet.url,
                                 contact_email: "info@sapphire.event",
                                 start_date: sapphire_start_date,
                                 end_date: sapphire_start_date + 1,

--- a/spec/controllers/proposals_controller_spec.rb
+++ b/spec/controllers/proposals_controller_spec.rb
@@ -28,9 +28,7 @@ describe ProposalsController, type: :controller do
           session_format_id: proposal.session_format.id,
           speakers_attributes: {
             '0' => {
-              bio: 'my bio',
-              user_id: user.id,
-              event_id: event.id
+              bio: 'my bio'
             }
           }
         }

--- a/spec/factories/program_sessions.rb
+++ b/spec/factories/program_sessions.rb
@@ -1,13 +1,19 @@
 FactoryGirl.define do
   factory :program_session do
-    title 'Default Session'
-    abstract 'Just some abstract'
+    sequence(:title) { |i| "Default Session #{i}" }
+    abstract "Just some abstract"
     state ProgramSession::ACTIVE
     session_format
-    event
+    event { Event.first || FactoryGirl.create(:event) }
 
     factory :program_session_with_proposal do
       proposal { FactoryGirl.build(:proposal, state: Proposal::ACCEPTED) }
+
+      trait :with_speaker do
+        after(:create) do |program_session|
+          program_session.speakers << FactoryGirl.create(:speaker, event: program_session.event)
+        end
+      end
     end
   end
 end

--- a/spec/factories/session_formats.rb
+++ b/spec/factories/session_formats.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :session_format do
     event { Event.first || FactoryGirl.create(:event) }
-    name Faker::Book.genre
+    sequence(:name) { |i| "Session Format#{i}" }
     description Faker::Company.catch_phrase
     duration 30
     add_attribute :public, true

--- a/spec/factories/speakers.rb
+++ b/spec/factories/speakers.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :speaker do
     user
-    event
-    bio 'Factory bio'
+    event { Event.first || FactoryGirl.create(:event) }
+    bio "Speaker bio"
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,10 +1,14 @@
 FactoryGirl.define do
+  sequence :name do |n|
+    "User Name #{n}"
+  end
+
   sequence :email do |n|
     "email#{n}@factory.com"
   end
 
   factory :user do
-    name "John Doe"
+    name
     email
     password "12345678"
     password_confirmation "12345678"

--- a/spec/features/notification_spec.rb
+++ b/spec/features/notification_spec.rb
@@ -13,6 +13,9 @@ feature "User's can interact with notifications" do
         visit root_path
         within ".navbar" do
           expect(page).to have_link("", href: "/notifications")
+        end
+
+        within ".badge" do
           expect(page).to_not have_content("1")
         end
       end

--- a/spec/features/staff/speakers_spec.rb
+++ b/spec/features/staff/speakers_spec.rb
@@ -1,0 +1,237 @@
+require 'rails_helper'
+
+feature "Organizers can manage speakers for Program Sessions" do
+
+  let(:event) { create(:event) }
+
+  let(:proposal_1) { create(:proposal, event: event) }
+  let(:proposal_2) { create(:proposal, event: event) }
+
+  let(:program_session_1) { create(:program_session_with_proposal, event: event) }
+  let(:program_session_2) { create(:program_session_with_proposal, event: event) }
+
+  let(:organizer_user) { create(:user) }
+  let!(:event_staff_teammate) { create(:teammate, :organizer, user: organizer_user, event: event) }
+
+  let(:speaker_user_1) { create(:user) }
+  let!(:speaker_1) { create(:speaker, proposal: proposal_1,
+                                      user: speaker_user_1) }
+
+  let(:speaker_user_2) { create(:user) }
+  let!(:speaker_2) { create(:speaker, proposal: proposal_2,
+                                      user: speaker_user_2) }
+
+  let(:speaker_user_3) { create(:user) }
+  let!(:speaker_3) { create(:speaker, program_session: program_session_1,
+                                      user: speaker_user_3) }
+
+  let(:speaker_user_4) { create(:user) }
+  let!(:speaker_4) { create(:speaker, program_session: program_session_1,
+                                      user: speaker_user_4) }
+
+  let(:speaker_user_5) { create(:user) }
+  let!(:speaker_5) { create(:speaker, program_session: program_session_2,
+                                      user: speaker_user_5) }
+
+  before :each do
+    logout
+    login_as(organizer_user)
+    visit event_staff_speakers_path(event)
+  end
+
+  context "An organizer" do
+    it "Only sees speakers of program sessions" do
+      expect(page).to have_content(speaker_3.name)
+      expect(page).to have_content(speaker_3.email)
+      # check for program session title linking to ?program session show page?
+
+      expect(page).to have_content(speaker_4.name)
+      expect(page).to have_content(speaker_4.email)
+
+      expect(page).to have_content(speaker_5.name)
+      expect(page).to have_content(speaker_5.email)
+
+      expect(page).to_not have_content(speaker_1.name)
+      expect(page).to_not have_content(speaker_1.email)
+
+      expect(page).to_not have_content(speaker_2.name)
+      expect(page).to_not have_content(speaker_2.email)
+    end
+
+    it "Only sees remove button if program session has mutiple speakers" do
+      row_1 = find("tr#speaker-#{speaker_3.id}")
+      row_2 = find("tr#speaker-#{speaker_4.id}")
+      row_3 = find("tr#speaker-#{speaker_5.id}")
+
+      within row_1 do
+        expect(page).to have_link "Remove"
+      end
+
+      within row_2 do
+        expect(page).to have_link "Remove"
+      end
+
+      within row_3 do
+        expect(page).to_not have_link "Remove"
+      end
+    end
+
+    it "Can add a new speaker to a program session" do
+      row = find("tr#speaker-#{speaker_5.id}")
+      within row do
+        click_on "Add Speaker"
+      end
+
+      expect(current_path).to eq(new_event_staff_program_session_speaker_path(event, program_session_2.id))
+      fill_in "speaker[speaker_name]", with: "Zorro"
+      fill_in "speaker[speaker_email]", with: "zorro@swords.com"
+      click_on "Save"
+
+      expect(current_path).to eq(event_staff_speakers_path(event))
+
+      expect(page).to have_content "Zorro has been added to #{program_session_2.title}"
+
+      expect(page).to have_css("tr#speaker-#{speaker_1.user_id}")
+      expect(page).to have_content "Zorro"
+      expect(page).to have_content "zorro@swords.com"
+
+      within "tr#speaker-#{Speaker.last.id}" do
+        expect(page).to have_content(program_session_2.title)
+      end
+    end
+
+    it "Can't add a new speaker with an invalid email" do
+      row = find("tr#speaker-#{speaker_5.id}")
+      within row do
+        click_on "Add Speaker"
+      end
+
+      fill_in "speaker[speaker_name]", with: "Orion"
+      fill_in "speaker[speaker_email]", with: "dkfjasdlkjflkdfkl"
+      click_on "Save"
+
+      expect(page).to have_content "There was a problem saving this speaker."
+    end
+
+    it "Can't add a speaker without an email" do
+      row = find("tr#speaker-#{speaker_5.id}")
+      within row do
+        click_on "Add Speaker"
+      end
+
+      fill_in "speaker[speaker_name]", with: "Orion"
+      fill_in "speaker[speaker_email]", with: ""
+      click_on "Save"
+
+      expect(page).to have_content "There was a problem saving this speaker."
+    end
+
+    it "Can't add a speaker without a name" do
+      row = find("tr#speaker-#{speaker_5.id}")
+      within row do
+        click_on "Add Speaker"
+      end
+
+      fill_in "speaker[speaker_name]", with: ""
+      fill_in "speaker[speaker_email]", with: "goodemail@example.com"
+      click_on "Save"
+
+      expect(page).to have_content "There was a problem saving this speaker."
+    end
+
+    it "Can edit a program sessions speaker" do
+      row = find("tr#speaker-#{speaker_3.id}")
+      old_name = speaker_3.name
+      old_email = speaker_3.email
+      old_bio = speaker_3.bio
+
+      within row do
+        expect(page).to have_content(old_name)
+        expect(page).to have_content(old_email)
+        click_on "Edit"
+      end
+
+      expect(current_path).to eq(edit_event_staff_speaker_path(event, speaker_3))
+
+      fill_in "speaker[speaker_name]", with: "New Name"
+      fill_in "speaker[speaker_email]", with: "new@email.com"
+      fill_in "speaker[bio]", with: "New bio!"
+
+      click_on "Save"
+
+      expect(current_path).to eq(event_staff_speakers_path(event))
+
+      expect(page).to_not have_content(old_name)
+      expect(page).to_not have_content(old_email)
+
+      expect(page).to have_content "New Name"
+      expect(page).to have_content "new@email.com"
+
+      # User name and email remain the same
+      expect(speaker_3.name).to eq old_name
+      expect(speaker_3.email).to eq old_email
+      expect(speaker_3.bio).to eq old_bio
+
+      # Speaker record is updated separately
+      speaker_profile = Speaker.find_by(id: speaker_3.id)
+      expect(speaker_profile.name).to eq "New Name"
+      expect(speaker_profile.email).to eq "new@email.com"
+      expect(speaker_profile.bio).to eq "New bio!"
+    end
+
+    it "Can't update a speaker with a bad email" do
+      row = find("tr#speaker-#{speaker_3.id}")
+      within row do
+        click_on "Edit"
+      end
+
+      fill_in "speaker[speaker_name]", with: "Penny"
+      fill_in "speaker[speaker_email]", with: "gobbiltygook"
+      click_on "Save"
+
+      expect(page).to have_content "There was a problem updating this speaker."
+    end
+
+    it "Can't update a speaker to have no email" do
+      pending "Currently you *can* update a speaker associated with a user to have no email - investigating"
+      row = find("tr#speaker-#{speaker_3.id}")
+      within row do
+        click_on "Edit"
+      end
+
+      fill_in "speaker[speaker_name]", with: "Penny"
+      fill_in "speaker[speaker_email]", with: ""
+      click_on "Save"
+
+      expect(page).to have_content "There was a problem updating this speaker."
+    end
+
+    it "Can't update a speaker to have no name" do
+      pending "Currently you *can* update a speaker associated with a user to have no name - investigating"
+      row = find("tr#speaker-#{speaker_3.id}")
+      within row do
+        click_on "Edit"
+      end
+
+      fill_in "speaker[speaker_name]", with: ""
+      fill_in "speaker[speaker_email]", with: "goodemail@example.com"
+      click_on "Save"
+
+      expect(page).to have_content "There was a problem updating this speaker."
+    end
+
+    it "Can delete a program session speaker", js: true do
+      row = find("tr#speaker-#{speaker_4.id}")
+    
+      within row do
+        page.accept_confirm { click_on "Remove" }
+      end
+
+      expect(page).to have_content "#{speaker_4.name} has been removed from #{speaker_4.program_session.title}."
+      page.reset!
+
+      expect(page).to_not have_content speaker_4.name
+      expect(page).to_not have_content speaker_4.email
+    end
+  end
+end


### PR DESCRIPTION
- Wires up staff/program/speakers route for organizer speaker management
- Adds has_many speakers association to program session model
- Shifts speaker association from proposals to program sessions
- Fixes routes to allow program session speaker creation
- Adds feature tests for all CRUD
