### PR TITLE
147-clarify-speaker-submit-process

### DIFF
--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -122,11 +122,11 @@ class ProposalsController < ApplicationController
   end
 
   def setup_flash_message
-    message = "Thank you for submitting a proposal."
+    message = "Thank you! Your proposal has been submitted and may be reviewed at any time while the CFP is open.\n\n"
+    message << "You are welcome to update your proposal or leave a comment at any time, just please be sure to preserve your anonymity.\n\n"
 
     if @event.closes_at
-      message +=
-        " Expect a response after the CFP closes on #{@event.closes_at.to_s(:long)}."
+      message << "Expect a response regarding acceptance after the CFP closes on #{@event.closes_at.to_s(:long)}."
     end
   end
 

--- a/app/views/proposals/_form.html.haml
+++ b/app/views/proposals/_form.html.haml
@@ -19,7 +19,7 @@
 
   - if event.public_tags?
     .form-group
-      %h3.control-label 
+      %h3.control-label
         Tags
       = f.select :tags,
         options_for_select(event.proposal_tags, proposal.object.tags),
@@ -33,7 +33,7 @@
   = f.input :details, input_html: { class: 'watched', rows: 5 },
     hint: 'Include any pertinent details such as outlines, outcomes or intended audience.'#, popover_icon: { content: details_tooltip }
 
-  = f.input :pitch, input_html: { class: 'watched', rows: 5 }, 
+  = f.input :pitch, input_html: { class: 'watched', rows: 5 },
     hint: 'Explain why this talk should be considered and what makes you qualified to speak on the topic.'#, popover_icon: { content: pitch_tooltip }
 
 - if event.custom_fields.any?
@@ -49,6 +49,4 @@
     = link_to "Cancel", event_proposal_path(event_slug: event.slug, uuid: proposal), {class: "btn btn-default btn-lg"}
   - else
     = link_to "Cancel", event_path(event.slug), {class: "btn btn-default btn-lg"}
-  %button.btn.btn-primary.btn-lg{type: "submit"} Save
-
-
+  %button.btn.btn-primary.btn-lg{type: "submit"} Submit

--- a/app/views/proposals/new.html.haml
+++ b/app/views/proposals/new.html.haml
@@ -4,13 +4,13 @@
       .event-info.event-info-dense
         %strong.event-title= event.name
         - if event.start_date? && event.end_date?
-          %span.event-meta 
+          %span.event-meta
             %i.fa.fa-fw.fa-calendar
             = event.date_range
     .col-md-4.text-right.text-right-responsive
       .event-info.event-info-dense
         %span{:class => "event-meta event-status-badge event-status-#{event.status}"}
-          CFP 
+          CFP
           = event.status
         - if event.open?
           %span.event-meta

--- a/spec/features/proposal_spec.rb
+++ b/spec/features/proposal_spec.rb
@@ -15,14 +15,14 @@ feature "Proposals" do
     fill_in 'Pitch', with: "You live but once; you might as well be amusing. - Coco Chanel"
     fill_in 'Details', with: "Plans are nothing; planning is everything. - Dwight D. Eisenhower"
     select 'Only format', from: 'Session format'
-    click_button 'Save'
+    click_button 'Submit'
   end
 
   let(:create_invalid_proposal) do
     fill_in 'proposal_speakers_attributes_0_bio', with: "I am a great speaker!."
     fill_in 'Pitch', with: "You live but once; you might as well be amusing. - Coco Chanel"
     fill_in 'Details', with: "Plans are nothing; planning is everything. - Dwight D. Eisenhower"
-    click_button 'Save'
+    click_button 'Submit'
   end
 
   before { login_as(user) }
@@ -89,7 +89,7 @@ feature "Proposals" do
       it "submits successfully" do
         expect(Proposal.last.abstract).to_not match('<p>')
         expect(Proposal.last.abstract).to_not match('</p>')
-        expect(page).to have_text("Thank you for submitting")
+        expect(page).to have_text("Thank you! Your proposal has been submitted and may be reviewed at any time while the CFP is open.")
       end
 
       it "does not create an empty comment" do
@@ -115,7 +115,7 @@ feature "Proposals" do
       visit edit_event_proposal_path(event_slug: proposal.event.slug, uuid: proposal)
       expect(page).to_not have_text("A new title")
       fill_in 'Title', with: "A new title"
-      click_button 'Save'
+      click_button 'Submit'
       expect(page).to have_text("A new title")
     end
   end


### PR DESCRIPTION
Adds more descriptive language to speaker message after submitting a proposal
