### PR TITLE
#152 require contact email

### DIFF
--- a/app/controllers/staff/application_controller.rb
+++ b/app/controllers/staff/application_controller.rb
@@ -13,6 +13,14 @@ class Staff::ApplicationController < ApplicationController
     end
   end
 
+  def require_contact_email
+    if @event.contact_email.empty?
+      session[:target] = request.path
+      flash[:danger] = "You must set a contact email for this event before inviting teammates."
+      redirect_to event_staff_edit_path(@event)
+    end
+  end
+
   def staff_signed_in?
     user_signed_in? && @event && (current_user.organizer_for_event?(@event) || current_user.reviewer_for_event?(@event))
   end

--- a/app/controllers/staff/events_controller.rb
+++ b/app/controllers/staff/events_controller.rb
@@ -24,10 +24,10 @@ class Staff::EventsController < Staff::ApplicationController
   def update_guidelines
     authorize_update
     if @event.update(params.require(:event).permit(:guidelines))
-      flash[:info] = 'Your guidelines were updated.'
+      flash[:info] = "Your guidelines were updated."
       redirect_to event_staff_guidelines_path
     else
-      flash[:danger] = 'There was a problem saving your guidelines; please review the form for issues and try again.'
+      flash[:danger] = "There was a problem saving your guidelines; please review the form for issues and try again."
       render :guidelines
     end
   end
@@ -38,9 +38,9 @@ class Staff::EventsController < Staff::ApplicationController
   def update_status
     authorize_update
     if @event.update(params.require(:event).permit(:state))
-      redirect_to event_staff_info_path(@event), notice: 'Event status was successfully updated.'
+      redirect_to event_staff_info_path(@event), notice: "Event status was successfully updated."
     else
-      flash[:danger] = 'There was a problem updating the event status. Please try again.'
+      flash[:danger] = "There was a problem updating the event status. Please try again."
       render :info
     end
   end
@@ -81,10 +81,15 @@ class Staff::EventsController < Staff::ApplicationController
   def update
     authorize_update
     if @event.update_attributes(event_params)
-      flash[:info] = 'Your event was saved.'
-      redirect_to event_staff_info_path(@event)
+      flash[:info] = "Your event was saved."
+      if session[:target]
+        redirect_to session[:target]
+        session[:target].clear
+      else
+        redirect_to event_staff_info_path(@event)
+      end
     else
-      flash[:danger] = 'There was a problem saving your event; please review the form for issues and try again.'
+      flash[:danger] = "There was a problem saving your event; please review the form for issues and try again."
       render :edit
     end
   end

--- a/app/controllers/staff/proposal_reviews_controller.rb
+++ b/app/controllers/staff/proposal_reviews_controller.rb
@@ -1,6 +1,6 @@
 class Staff::ProposalReviewsController < Staff::ApplicationController
-  before_filter :require_proposal, except: [:index]
-  before_filter :prevent_self, except: [:index]
+  before_action :require_proposal, except: [:index]
+  before_action :prevent_self, except: [:index]
 
   decorates_assigned :proposal, with: Staff::ProposalDecorator
   respond_to :html, :js

--- a/app/controllers/staff/teammates_controller.rb
+++ b/app/controllers/staff/teammates_controller.rb
@@ -2,6 +2,7 @@ class Staff::TeammatesController < Staff::ApplicationController
   # what is this? review this line - probably junk
   skip_before_filter :require_proposal, only: [:update], if: proc {|c| current_user && current_user.reviewer? }
   before_action :enable_staff_subnav
+  before_action :require_contact_email, only: [:create]
   respond_to :html, :json
 
   def index
@@ -16,7 +17,7 @@ class Staff::TeammatesController < Staff::ApplicationController
     invitation = current_event.teammates.build(params.require(:teammate).permit(:email, :role))
 
     if invitation.invite
-      TeammateInvitationMailer.create(invitation).deliver_now
+        TeammateInvitationMailer.create(invitation).deliver_now
       redirect_to event_staff_teammates_path(current_event),
         flash: { info: "Invitation to #{invitation.email} was sent."}
     else

--- a/spec/features/staff/teammates_spec.rb
+++ b/spec/features/staff/teammates_spec.rb
@@ -26,6 +26,22 @@ feature "Staff Organizers can manage teammates" do
       expect(page).to have_text("harrypotter@hogwarts.edu")
       expect(page).to have_text("pending")
     end
+
+    it "invitation can't be sent if contact email isn't set", js: true do
+      incomplete_event = create(:event, name: "My Event", contact_email: "")
+      create(:teammate, event: incomplete_event, user: organizer_user, role: "organizer")
+
+      login_as(organizer_user)
+      visit event_staff_teammates_path(incomplete_event)
+
+      click_link "Invite new teammate"
+      fill_in "Email", with: "harrypotter@hogwarts.edu"
+      select("reviewer", from: "Role")
+      click_button "Invite"
+
+      expect(current_path).to eq(event_staff_edit_path(incomplete_event))
+      expect(page).to have_content "You must set a contact email for this event before inviting teammates."
+    end
   end
 
   context "editing existing teammates" do


### PR DESCRIPTION
Adds logic to require a contact email on the event before teammate invitations can be sent out. If no contact email is set, the organizer is redirected to the edit page to add one and then sent back to the teammates page to continue invitations.
