### PR TITLE
#168 organizer edit track

### DIFF
--- a/app/assets/javascripts/staff/program/selection.js
+++ b/app/assets/javascripts/staff/program/selection.js
@@ -26,4 +26,18 @@ $(function() {
       });
     }
   });
+
+  $(document).on('change', '.proposal-track-select', function () {
+    $trackSelect = $(this);
+    var trackId = $trackSelect.val();
+    var url = $trackSelect.data('targetPath');
+
+    $trackSelect.closest('td').load(url, { track_id: trackId });
+    // {
+    //   url: url,
+    //   dataType: 'json',
+    //   data: { track_id: trackId },
+    //   type: 'POST'
+    // });
+  });
 });

--- a/app/assets/javascripts/staff/program/selection.js
+++ b/app/assets/javascripts/staff/program/selection.js
@@ -32,7 +32,7 @@ $(function() {
     var trackId = $trackSelect.val();
     var url = $trackSelect.data('targetPath');
 
-    $trackSelect.closest('td').load(url, { track_id: trackId });
+    $trackSelect.closest('td, span, div').load(url, { track_id: trackId });
     // {
     //   url: url,
     //   dataType: 'json',

--- a/app/controllers/staff/proposals_controller.rb
+++ b/app/controllers/staff/proposals_controller.rb
@@ -2,7 +2,7 @@ class Staff::ProposalsController < Staff::ApplicationController
   before_action :enable_staff_program_subnav
   before_action :set_proposal_counts
 
-  before_action :require_proposal, only: [:show, :update_state, :finalize]
+  before_action :require_proposal, only: [:show, :update_state, :update_track, :finalize]
 
   decorates_assigned :proposal, with: Staff::ProposalDecorator
 
@@ -34,6 +34,14 @@ class Staff::ProposalsController < Staff::ApplicationController
       format.html { redirect_to event_staff_program_proposals_path(@proposal.event) }
       format.js
     end
+  end
+
+  def update_track
+    authorize @proposal
+
+    @proposal.update(track_id: params[:track_id])
+
+    render partial: '/staff/proposals/inline_track_edit'
   end
 
   def selection

--- a/app/decorators/proposal_decorator.rb
+++ b/app/decorators/proposal_decorator.rb
@@ -133,6 +133,16 @@ class ProposalDecorator < ApplicationDecorator
       hint: 'A concise, engaging description for the public program. Limited to 600 characters.'#, popover_icon: { content: tooltip }
   end
 
+  def standalone_track_select()
+
+    h.select_tag :track, h.options_for_select(track_options, object.track_id), include_blank: 'General – No Suggested Track',
+               class: 'proposal-track-select', data: { target_path: h.event_staff_program_proposal_update_track_path(object.event, object) }
+  end
+
+  def track_options
+    @track_options ||= object.event.tracks.map {|t| [t.name, t.id]}
+  end
+
   private
 
   def speaker

--- a/app/policies/proposal_policy.rb
+++ b/app/policies/proposal_policy.rb
@@ -16,6 +16,10 @@ class ProposalPolicy < ApplicationPolicy
     @user.program_team_for_event?(@current_event)
   end
 
+  def update_track?
+    @user.program_team_for_event?(@current_event)
+  end
+
   def finalize?
     @user.organizer_for_event?(@current_event)
   end

--- a/app/views/proposals/_form.html.haml
+++ b/app/views/proposals/_form.html.haml
@@ -2,7 +2,6 @@
   = proposal.title_input(f)
 
   - opts_session_formats = event.session_formats.publicly_viewable.map {|st| [st.name, st.id]}
-
   - if opts_session_formats.length > 1
     = f.association :session_format, collection: opts_session_formats, include_blank: 'None selected', required: true, input_html: {class: 'dropdown'},
       hint: "The format your proposal will follow."#, popover_icon: { content: session_format_tooltip }
@@ -10,10 +9,15 @@
     = f.association :session_format, collection: opts_session_formats, include_blank: false, input_html: {readonly: "readonly"},
       hint: "The format your proposal will follow."#, popover_icon: { content: "Only One Session Format for #{event.name}" }
 
-  - opts_tracks = event.tracks.map {|t| [t.name, t.id]}
-  -if opts_tracks.length > 0
+  - if event.multiple_tracks? && !proposal.has_reviewer_activity?
+    - opts_tracks = event.tracks.map {|t| [t.name, t.id]}
     = f.association :track, collection: opts_tracks, include_blank: 'General – No Suggested Track', input_html: {class: 'dropdown'},
       hint: "Optional: suggest a specific track to be considered for."#, popover_icon: { content: track_tooltip }
+  - else
+    .form-group
+      = f.label :track, 'Track'
+      %div #{proposal.track_name}
+
 
   = proposal.abstract_input(f, abstract_tooltip)
 

--- a/app/views/staff/proposal_reviews/update.js.erb
+++ b/app/views/staff/proposal_reviews/update.js.erb
@@ -1,2 +1,1 @@
 document.getElementById('flash').innerHTML = '<%=j show_flash %>';
-$('.proposal-reviewer-tags').html('<%=j proposal.review_tags_labels %>');

--- a/app/views/staff/proposals/_inline_track_edit.html.haml
+++ b/app/views/staff/proposals/_inline_track_edit.html.haml
@@ -1,0 +1,4 @@
+- if proposal.event.multiple_tracks?
+  = proposal.standalone_track_select
+- else
+  = proposal.track_name

--- a/app/views/staff/proposals/selection.html.haml
+++ b/app/views/staff/proposals/selection.html.haml
@@ -63,7 +63,8 @@
             %td= proposal.average_rating
             %td= proposal.speaker_names
             %td= proposal.title_link
-            %td= proposal.track_name
+            %td
+              = render 'inline_track_edit', proposal: proposal
             %td= proposal.session_format_name
             %td= proposal.review_tags_labels
             %td

--- a/app/views/staff/proposals/show.html.haml
+++ b/app/views/staff/proposals/show.html.haml
@@ -43,9 +43,6 @@
             .proposal-meta-item
               %strong Format:
               %span #{proposal.session_format_name}
-            .proposal-meta-item
-              %strong Track:
-              %span #{proposal.track_name}
             -if proposal.tags.present?
               .proposal-meta-item
                 %strong Tags:
@@ -53,6 +50,10 @@
       .col-sm-6.text-right
         .proposal-info-bar
           .proposal-meta.proposal-description
+            .proposal-meta-item
+              %strong Track:
+              %span
+                = render 'inline_track_edit', proposal: proposal
             .proposal-meta-item
               %strong Status:
               %span.proposal-status #{proposal.state_label(small: true)}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,6 +64,7 @@ Rails.application.routes.draw do
           end
           post :finalize
           post :update_state
+          post :update_track
         end
 
         resources :speakers, only: [:index, :show, :edit, :update, :destroy]


### PR DESCRIPTION
- Lock down track editing for speakers once there's reviewer activity on a proposal.
- Create inline track select on program selection page.
