### PR TITLE
#177 Program Bar Tweaks

### DIFF
--- a/app/assets/javascripts/staff/program/selection.js
+++ b/app/assets/javascripts/staff/program/selection.js
@@ -6,8 +6,8 @@ $(function() {
 
   $('.track-select').change(function () {
     var successFn = function (data) {
-      $('.by-track.soft-accepted').find('.badge').text(data.soft_accepted_count);
-      $('.by-track.soft-waitlisted').find('.badge').text(data.soft_waitlisted_count);
+      $('.by-track.all-accepted').find('.badge').text(data.all_accepted_count);
+      $('.by-track.all-waitlisted').find('.badge').text(data.all_waitlisted_count);
       $('.by-track').show();
     };
 
@@ -18,9 +18,9 @@ $(function() {
       $('.by-track').hide();
     } else {
       $.ajax({
-        url: '/events/' + eventSlug + '/staff/program/proposals/program_counts',
+        url: '/events/' + eventSlug + '/staff/program/proposals/session_counts',
         dataType: 'json',
-        data: { trackId: trackId },
+        data: { track_id: trackId },
         type: 'GET',
         success: successFn
       });

--- a/app/assets/stylesheets/modules/_navbar.scss
+++ b/app/assets/stylesheets/modules/_navbar.scss
@@ -3,22 +3,40 @@
 }
 
 .navbar-nav {
-  &.program-counts {
-    .split {
-      clear: left;
+  &.session-counts {
+    .title {
+      color: #fff;
     }
 
-    .no-top-padding {
-      padding-top: 0
+    .track-select {
+      margin-left: 6px;
+    }
+
+    .counts-container {
+      font-size: $font-size-xs;
+      margin-left: 6px;
+
+      .badge {
+        font-size: $font-size-xs;
+        margin-top: -2px;
+        padding: 1px 8px;
+      }
+
+      .all-accepted > span:first-child,
+      .all-waitlisted > span:first-child {
+        display: inline-block;
+        width: 55px;
+      }
     }
   }
 
+
   li.static {
+    height: 58px;
+    display: inline-flex;
+    align-items: center;
     color: #ccc;
     padding-left: 15px;
-    padding-right: 15px;
-    padding-bottom:    $navbar-padding-vertical;
-    padding-top:    $navbar-padding-vertical;
 
     .track-select {
       display: inline;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -138,7 +138,7 @@ class ApplicationController < ActionController::Base
   end
 
   def set_proposal_counts
-    @soft_accepted_count ||= Proposal.soft_accepted_count(current_event)
-    @soft_waitlisted_count ||= Proposal.soft_waitlisted_count(current_event)
+    @all_accepted_count ||= Proposal.all_accepted_count(current_event)
+    @all_waitlisted_count ||= Proposal.all_waitlisted_count(current_event)
   end
 end

--- a/app/controllers/staff/proposals_controller.rb
+++ b/app/controllers/staff/proposals_controller.rb
@@ -54,11 +54,11 @@ class Staff::ProposalsController < Staff::ApplicationController
     @taggings_count = Tagging.count_by_tag(@event)
   end
 
-  def program_counts
-    track = params[:trackId]
-    render :json =>
-      { :soft_accepted_count => Proposal.soft_accepted_count(current_event, track),
-        :soft_waitlisted_count => Proposal.soft_waitlisted_count(current_event, track)
+  def session_counts
+    track = params[:track_id]
+    render json: {
+        all_accepted_count: Proposal.all_accepted_count(current_event, track),
+        all_waitlisted_count: Proposal.all_waitlisted_count(current_event, track)
       }
   end
 

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -258,6 +258,18 @@ class Proposal < ActiveRecord::Base
     q.size
   end
 
+  def self.all_accepted_count(event, track='all')
+    q = event.proposals.where(state: [ACCEPTED, SOFT_ACCEPTED])
+    q = q.in_track(track) unless track=='all'
+    q.size
+  end
+
+  def self.all_waitlisted_count(event, track='all')
+    q = event.proposals.where(state: [WAITLISTED, SOFT_WAITLISTED])
+    q = q.in_track(track) unless track=='all'
+    q.size
+  end
+
   private
 
   def save_tags

--- a/app/views/layouts/_navbar.html.haml
+++ b/app/views/layouts/_navbar.html.haml
@@ -27,7 +27,7 @@
 
           - if program_nav?
             %li{class: nav_item_class("event-program-link")}
-              = link_to selection_event_staff_program_proposals_path(current_event) do
+              = link_to event_staff_program_proposals_path(current_event) do
                 %i.fa.fa-sitemap
                 %span Program
 

--- a/app/views/layouts/nav/staff/_program_subnav.html.haml
+++ b/app/views/layouts/nav/staff/_program_subnav.html.haml
@@ -1,14 +1,14 @@
 .navbar.navbar-default.program-subnav
   .container-fluid
     %ul.nav.navbar-nav.navbar-right
-      %li{class: program_subnav_item_class("event-program-proposals-selection-link")}
-        = link_to selection_event_staff_program_proposals_path do
-          %i.fa.fa-gavel
-          %span Selection
       %li{class: program_subnav_item_class("event-program-proposals-link")}
         = link_to event_staff_program_proposals_path do
           %i.fa.fa-balance-scale
           %span Proposals
+      %li{class: program_subnav_item_class("event-program-proposals-selection-link")}
+        = link_to selection_event_staff_program_proposals_path do
+          %i.fa.fa-gavel
+          %span Selection
       %li{class: program_subnav_item_class("event-program-sessions-link")}
         = link_to event_staff_program_sessions_path do
           %i.fa.fa-check
@@ -18,27 +18,30 @@
           %i.fa.fa-users
           %span Speakers
 
-    %ul.nav.navbar-nav.program-counts
+    %ul.nav.navbar-nav.session-counts
       %li.static
-        %span Program Count:
-      %li.static.total.soft-accepted
-        %span Soft Accepted
-        %span.badge= @soft_accepted_count
-      %li.static.total.soft-waitlisted
-        %span Soft Waitlisted
-        %span.badge= @soft_waitlisted_count
+        %span.title Sessions:
+        %div.counts-container
+          .total.all-accepted
+            %span Accepted
+            %span.badge= @all_accepted_count
+          .total.all-waitlisted
+            %span Waitlisted
+            %span.badge= @all_waitlisted_count
+
       - if program_tracks.any?
-        %li.static.no-top-padding.split
-          %span By Track:
-          %form.track-select{:data => {:event => current_event.slug}}
-            %select{:id => 'track-select', :name => 'track'}
-              %option{:value => 'all'} All
-              %option{:value => 'general'} General
+        %li.static
+          %span.title By Track:
+          %form.track-select{data: {event: current_event.slug}}
+            %select{id: 'track-select', name: 'track'}
+              %option{value: 'all'} All
+              %option General
               - program_tracks.each do |track|
-                %option{:value => track.id}= track.name
-        %li.static.no-top-padding.by-track.soft-accepted
-          %span Soft Accepted
-          %span.badge 0
-        %li.static.no-top-padding.by-track.soft-waitlisted
-          %span Soft Waitlisted
-          %span.badge 0
+                %option{value: track.id}= track.name
+          %div.counts-container
+            .by-track.all-accepted
+              %span Accepted
+              %span.badge 0
+            .by-track.all-waitlisted
+              %span Waitlisted
+              %span.badge 0

--- a/app/views/staff/proposals/selection.html.haml
+++ b/app/views/staff/proposals/selection.html.haml
@@ -27,11 +27,11 @@
   .col-sm-8.text-left
     %ul.selection-counts
       %li.total.soft-accepted
-        %span Soft Accepted
-        %span.badge= @soft_accepted_count
+        %span Accepted
+        %span.badge= @all_accepted_count
       %li.total.soft-waitlisted
-        %span Soft Waitlisted
-        %span.badge= @soft_waitlisted_count
+        %span Waitlisted
+        %span.badge= @all_waitlisted_count
   .col-sm-4.text-right
     %small.text-right <em>Hint:</em> Hold <kbd>shift</kbd> to sort by multiple columns
 
@@ -63,8 +63,7 @@
             %td= proposal.average_rating
             %td= proposal.speaker_names
             %td= proposal.title_link
-            %td
-              = render 'inline_track_edit', proposal: proposal
+            %td= proposal.track_name
             %td= proposal.session_format_name
             %td= proposal.review_tags_labels
             %td

--- a/app/views/staff/proposals/show.html.haml
+++ b/app/views/staff/proposals/show.html.haml
@@ -32,7 +32,12 @@
       .col-md-6.text-right
         - if proposal.organizer_confirm
           = link_to "Confirm for Speaker", confirm_event_proposal_path(slug: proposal.event.slug, uuid: proposal), class: "btn btn-primary btn-sm"
-        %span.state-buttons #{proposal.state_buttons(show_finalize: false)}
+        .proposal-info-bar
+          .proposal-meta.proposal-description
+            .proposal-meta-item
+              %strong Status:
+              %span.proposal-status #{proposal.state_label(small: true)}
+            %span.state-buttons #{proposal.state_buttons(show_finalize: false)}
     .row
       .col-sm-6
         .proposal-info-bar
@@ -54,9 +59,6 @@
               %strong Track:
               %span
                 = render 'inline_track_edit', proposal: proposal
-            .proposal-meta-item
-              %strong Status:
-              %span.proposal-status #{proposal.state_label(small: true)}
             -if proposal.review_tags.present?
               .proposal-meta-item
                 %strong Reviewer Tags:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,7 +60,7 @@ Rails.application.routes.draw do
         resources :proposals, param: :uuid do
           collection do
             get 'selection'
-            get 'program_counts'
+            get 'session_counts'
           end
           post :finalize
           post :update_state


### PR DESCRIPTION
- Fiddled with language and layout of stats.
- Removed track dropdown from selection grid.
- Fixed a bug in the session stats by track.
- Moved state label to be closer to the state buttons (program proposal show).
- Combined regular and soft status in counts.
- Changed order of program subnav items, default page.
