### PR TITLE
#190 Non-blind proposal access

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,7 +15,7 @@ class ApplicationController < ActionController::Base
   helper_method :organizer?
   helper_method :event_staff?
   helper_method :display_staff_event_subnav?
-  helper_method :display_staff_program_subnav?
+  helper_method :program_mode?
   helper_method :program_tracks
 
   before_action :current_event
@@ -133,7 +133,7 @@ class ApplicationController < ActionController::Base
     @display_program_subnav = true
   end
 
-  def display_staff_program_subnav?
+  def program_mode?
     @display_program_subnav
   end
 

--- a/app/controllers/staff/application_controller.rb
+++ b/app/controllers/staff/application_controller.rb
@@ -39,9 +39,8 @@ class Staff::ApplicationController < ApplicationController
     user_signed_in? && current_user.reviewer?
   end
 
-  # Prevent reviewers from reviewing their own proposals.
-  def prevent_self
-    if @proposal.has_speaker?(current_user)
+  def prevent_self_review
+    if !program_mode? && @proposal.has_speaker?(current_user)
       flash[:notice] = "Can't review your own proposal!"
       redirect_to event_staff_proposals_url(event_slug: @proposal.event.slug)
     end

--- a/app/controllers/staff/proposal_reviews_controller.rb
+++ b/app/controllers/staff/proposal_reviews_controller.rb
@@ -1,12 +1,12 @@
 class Staff::ProposalReviewsController < Staff::ApplicationController
   before_action :require_proposal, except: [:index]
-  before_action :prevent_self, except: [:index]
+  before_action :prevent_self_review, except: [:index]
 
   decorates_assigned :proposal, with: Staff::ProposalDecorator
   respond_to :html, :js
 
   def index
-    authorize Proposal, :reviewer_index?
+    authorize Proposal, :reviewer?
     set_title('Review Proposals')
 
     proposals = policy_scope(Proposal)
@@ -22,7 +22,7 @@ class Staff::ProposalReviewsController < Staff::ApplicationController
   end
 
   def show
-    authorize @proposal, :reviewer_show?
+    authorize @proposal, :review?
     set_title(@proposal.title)
 
     rating = current_user.rating_for(@proposal)
@@ -34,7 +34,7 @@ class Staff::ProposalReviewsController < Staff::ApplicationController
   end
 
   def update
-    authorize @proposal, :reviewer_update?
+    authorize @proposal, :review?
 
     unless @proposal.update_without_touching_updated_by_speaker_at(proposal_review_tags_params)
       flash[:danger] = 'There was a problem saving the proposal.'

--- a/app/controllers/staff/proposals_controller.rb
+++ b/app/controllers/staff/proposals_controller.rb
@@ -1,6 +1,8 @@
 class Staff::ProposalsController < Staff::ApplicationController
   before_action :enable_staff_program_subnav
   before_action :set_proposal_counts, only: [:index, :show, :selection]
+  before_action :skip_policy_scope
+
 
   before_action :require_proposal, only: [:show, :update_state, :update_track, :finalize]
 

--- a/app/controllers/staff/ratings_controller.rb
+++ b/app/controllers/staff/ratings_controller.rb
@@ -1,13 +1,14 @@
 class Staff::RatingsController < Staff::ApplicationController
-  before_filter :require_proposal
-  before_filter :prevent_self
+  before_action :track_program_use
+  before_action :require_proposal
+  before_action :prevent_self_review
 
   respond_to :js
 
   decorates_assigned :proposal
 
   def create
-    authorize @proposal, :reviewer_update?
+    authorize @proposal, :rate?
 
     @rating = Rating.find_or_create_by(proposal: @proposal, user: current_user)
     @rating.update_attributes(rating_params)
@@ -20,7 +21,7 @@ class Staff::RatingsController < Staff::ApplicationController
   end
 
   def update
-    authorize @proposal, :reviewer_update?
+    authorize @proposal, :rate?
 
     @rating = current_user.rating_for(@proposal)
     if rating_params[:score].blank?
@@ -41,5 +42,11 @@ class Staff::RatingsController < Staff::ApplicationController
 
   def rating_params
     params.require(:rating).permit(:score).merge(proposal: @proposal, user: current_user)
+  end
+
+  def track_program_use
+    if params[:program]
+      enable_staff_program_subnav
+    end
   end
 end

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -8,4 +8,12 @@ module CommentsHelper
       'from_user left reviewer-comment'
     end
   end
+
+  def commenter_name(comment)
+    if program_mode?
+      comment.user.name
+    else
+      comment.proposal.has_speaker?(comment.user) ? 'speaker' : comment.user.name
+    end
+  end
 end

--- a/app/helpers/staff_helper.rb
+++ b/app/helpers/staff_helper.rb
@@ -1,0 +1,21 @@
+module StaffHelper
+
+  def allow_rating?(proposal)
+    program_mode? || !proposal.has_speaker?(current_user)
+  end
+
+  def show_ratings?(rating)
+    program_mode? || rating.persisted?
+  end
+
+  def show_proposal?(proposal)
+    program_mode? || !proposal.has_speaker?(current_user)
+  end
+
+  def program_tracker
+    if program_mode?
+      hidden_field_tag(:program, true)
+    end
+  end
+
+end

--- a/app/policies/proposal_policy.rb
+++ b/app/policies/proposal_policy.rb
@@ -1,15 +1,15 @@
 # Policy for Proposals, though for now covering blind review functionality.
 class ProposalPolicy < ApplicationPolicy
-  def reviewer_index?
+  def reviewer?
     @user.staff_for?(@current_event)
   end
 
-  def reviewer_show?
+  def review?
     @user.staff_for?(@current_event) && !@record.has_speaker?(@user)
   end
 
-  def reviewer_update?
-    @user.staff_for?(@current_event) && !@record.has_speaker?(@user)
+  def rate?
+    @user.staff_for?(@current_event)
   end
 
   def update_state?

--- a/app/views/layouts/_navbar.html.haml
+++ b/app/views/layouts/_navbar.html.haml
@@ -57,5 +57,5 @@
 - if display_staff_event_subnav?
   = render partial: "layouts/nav/staff/event_subnav"
 
-- elsif display_staff_program_subnav?
+- elsif program_mode?
   = render partial: "layouts/nav/staff/program_subnav"

--- a/app/views/proposals/_comments.html.haml
+++ b/app/views/proposals/_comments.html.haml
@@ -5,7 +5,7 @@
         - if comment.user.present?
           .info{ title: comment.created_at.to_s }
             %p.name
-              #{proposal.has_speaker?(comment.user) ? 'speaker' : comment.user.name}
+              = commenter_name(comment)
             %span.time #{comment.created_at.to_s(:day_at_time)}
         .text
           =markdown(comment.body)

--- a/app/views/shared/proposals/_rating_form.html.haml
+++ b/app/views/shared/proposals/_rating_form.html.haml
@@ -1,11 +1,12 @@
 #rating-form
-  - unless proposal.has_speaker?(current_user)
+  - if allow_rating?(proposal)
     = simple_form_for [event, :staff, proposal, rating], remote: true do |f|
+      = program_tracker
       = f.input :score, label: 'Rating', collection: (1..5), include_blank: true,
         input_html: { style: 'width: 60px', onchange: '$(this).trigger("submit.rails");'},
         disabled: proposal.withdrawn?, popover_icon: { content: rating_tooltip }
 
-  - unless rating.new_record?
+  - if show_ratings?(rating)
     %dl.dl-horizontal.ratings_list.margin-top
       - proposal.ratings.each do |rating|
         %dt= "#{rating.user.name}:"

--- a/app/views/staff/proposals/_proposal.html.haml
+++ b/app/views/staff/proposals/_proposal.html.haml
@@ -1,4 +1,4 @@
-- unless proposal.has_speaker?(current_user)
+- if show_proposal?(proposal)
   %tr{ class: "proposal-#{proposal.id}", data: { 'proposal-id' => proposal.id, 'proposal-uuid' => proposal.uuid } }
     %td= proposal.average_rating
     %td= proposal.ratings.size

--- a/app/views/staff/proposals/show.html.haml
+++ b/app/views/staff/proposals/show.html.haml
@@ -115,7 +115,7 @@
           -#  %h3 Slides URL
           -#  = proposal.proposal_data[:slides_url]
 
-        .internal-comments{ style: proposal.internal_comments_style }
+        .internal-comments
           .widget-header
             %i.fa.fa-comments
             %h3= pluralize(proposal.internal_comments.count, 'internal comment')


### PR DESCRIPTION
- Removed restriction on ratings & comment visibility for non-blind proposal show page.
- Removed prevent_self restriction on rating non-blind proposals.
- Refactored rating code into Proposal model.
- Created new rate actions on proposals and review_proposals controllers.
- Removed ratings_controller and views.
