### PR TITLE
#65-admin-event-management

### DIFF
--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -8,11 +8,11 @@ class Admin::EventsController < Admin::ApplicationController
   def create
     @event = Event.new(event_params)
     if @event.save
-			@event.teammates.build(email: current_user.email, role: 'organizer').accept(current_user)
-      flash[:info] = 'Your event was saved.'
+			@event.teammates.build(email: current_user.email, role: "organizer").accept(current_user)
+      flash[:info] = "Your event was saved."
       redirect_to event_staff_url(@event)
     else
-      flash[:danger] = 'There was a problem saving your event; please review the form for issues and try again.'
+      flash[:danger] = "There was a problem saving your event; please review the form for issues and try again."
       render :new
     end
   end

--- a/app/views/layouts/nav/_notifications_list.html.haml
+++ b/app/views/layouts/nav/_notifications_list.html.haml
@@ -19,4 +19,4 @@
       = link_to notifications_path do
         %i.fa.fa-eye
         %span
-          =  current_user.notifications.more_unread? ? "#{current_user.notifications.more_unread_count} More Unread" : "View All Notifications"
+          =  current_user.notifications.more_unread? ? "#{current_user.notifications.more_unread_count} More Unread" : "View all notifications"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -85,6 +85,7 @@ If your talk is about seed data in Rails apps, we want to hear about it!
   seed_event.rooms.create(name: "Venus Theater", room_number: "VEN-T", level: "2", address: "123 Universe Drive", capacity: 75)
 
   # Event Team
+  seed_event.teammates.create(user: admin, email: admin.email, role: "organizer", state: Teammate::ACCEPTED)
   seed_event.teammates.create(user: organizer, email: organizer.email, role: "organizer", state: Teammate::ACCEPTED, notifications: false)
   seed_event.teammates.create(user: track_director, email: track_director.email, role: "program team", state: Teammate::ACCEPTED)
   seed_event.teammates.create(user: reviewer, email: reviewer.email, role: "reviewer", state: Teammate::ACCEPTED)
@@ -290,6 +291,7 @@ If you are on the cutting edge with savvy Sapphire skills, we want you!
                                 review_tags: %w(beginner intermediate advanced))
 
   # Event Team
+  sapphire_event.teammates.create(user: admin, email: admin.email, role: "organizer", state: Teammate::ACCEPTED)
   sapphire_event.teammates.create(user: organizer, email: organizer.email, role: "organizer", state: Teammate::ACCEPTED)
 end
 

--- a/spec/features/admin/event_spec.rb
+++ b/spec/features/admin/event_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 feature "Event Dashboard" do
   let(:event) { create(:event, name: "My Event") }
@@ -6,7 +6,7 @@ feature "Event Dashboard" do
   let!(:admin_teammate) { create(:teammate,
                                    event: event,
                                    user: admin_user,
-                                   role: 'organizer'
+                                   role: "organizer"
                                   )
   }
 
@@ -22,8 +22,9 @@ feature "Event Dashboard" do
       fill_in "End date", with: DateTime.now + 15.days
       fill_in "Closes at", with: DateTime.now + 15.days
       click_button "Save"
-      admin_user.reload
-      expect(admin_user.organizer_events.last.name).to eql("My Other Event")
+
+      event = Event.last
+      expect(admin_user.organizer_for_event?(event)).to be(true)
     end
 
     it "must provide correct url syntax if a url is given" do
@@ -37,17 +38,16 @@ feature "Event Dashboard" do
     end
 
     it "can edit an event" do
-      skip "pending admin edit permissions discussion"
       visit event_staff_edit_path(event)
       fill_in "Name", with: "My Finest Event Evar For Realz"
-      click_button 'Save'
+      click_button "Save"
       expect(page).to have_text("My Finest Event Evar For Realz")
     end
 
     it "can delete events" do
       skip "pending admin delete permissions discussion"
       visit event_staff_edit_path(event)
-      click_link 'Delete Event'
+      click_link "Delete Event"
       expect(page).not_to have_text("My Event")
     end
   end

--- a/spec/features/notification_spec.rb
+++ b/spec/features/notification_spec.rb
@@ -52,7 +52,7 @@ feature "User's can interact with notifications" do
         visit root_path
         within ".navbar" do
           click_link("Notifications Toggle")
-          click_link("View All Notifications")
+          click_link("View all notifications")
         end
 
         expect(current_path).to eq(notifications_path)


### PR DESCRIPTION
Confirms that admin have organizer status upon event creation, fixes seeds to match this behavior, adds spec back in for admin event editing
