### PR TITLE
#183-video-and-slide-urls

### DIFF
--- a/app/controllers/staff/program_sessions_controller.rb
+++ b/app/controllers/staff/program_sessions_controller.rb
@@ -79,7 +79,7 @@ class Staff::ProgramSessionsController < Staff::ApplicationController
 
   def program_session_params
     params.require(:program_session).permit(:id, :session_format_id, :track_id, :title,
-                                            :abstract, :state,
+                                            :abstract, :state, :video_url, :slides_url,
                                             speakers_attributes: [:id, :bio, :speaker_name, :speaker_email])
   end
 

--- a/app/models/program_session.rb
+++ b/app/models/program_session.rb
@@ -16,6 +16,8 @@ class ProgramSession < ActiveRecord::Base
 
   validates :event, :session_format, :title, :state, presence: true
 
+  serialize :info, Hash
+
   after_destroy :destroy_speakers
 
   scope :unscheduled, -> do
@@ -71,6 +73,22 @@ class ProgramSession < ActiveRecord::Base
     time_slot.present?
   end
 
+  def video_url
+    info[:video_url]
+  end
+
+  def slides_url
+    info[:slides_url]
+  end
+
+  def video_url=(video_url)
+    info[:video_url] = video_url
+  end
+
+  def slides_url=(slides_url)
+    info[:slides_url] = slides_url
+  end
+
   private
 
   def destroy_speakers
@@ -92,6 +110,7 @@ end
 #  state             :text             default("active")
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
+#  info              :text
 #
 # Indexes
 #

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -31,7 +31,6 @@ class Proposal < ActiveRecord::Base
   serialize :proposal_data, Hash
 
   attr_accessor :tags, :review_tags, :updating_user
-  attr_accessor :video_url, :slide_url
 
   accepts_nested_attributes_for :public_comments, reject_if: Proc.new { |comment_attributes| comment_attributes[:body].blank? }
   accepts_nested_attributes_for :speakers
@@ -90,22 +89,6 @@ class Proposal < ActiveRecord::Base
       end
     end
     proposals
-  end
-
-  def video_url
-    proposal_data[:video_url]
-  end
-
-  def slides_url
-    proposal_data[:slides_url]
-  end
-
-  def video_url=(video_url)
-    proposal_data[:video_url] = video_url
-  end
-
-  def slides_url=(slides_url)
-    proposal_data[:slides_url] = slides_url
   end
 
   def custom_fields=(custom_fields)

--- a/app/serializers/program_session_serializer.rb
+++ b/app/serializers/program_session_serializer.rb
@@ -1,5 +1,5 @@
 class ProgramSessionSerializer < ActiveModel::Serializer
-  attributes :title, :abstract, :format, :track, :id#, :review_tags, :custom_fields, :video_url, :slides_url
+  attributes :title, :abstract, :format, :track, :id, :video_url, :slides_url
   has_many :speakers
 
   def review_tags

--- a/app/views/staff/program_sessions/_form.html.haml
+++ b/app/views/staff/program_sessions/_form.html.haml
@@ -9,12 +9,11 @@
         = f.input :state, as: :select, collection: session_states_collection, label: "State",
           include_blank: false, required: true
       = f.input :abstract, maxlength: 605, input_html: { class: 'watched js-maxlength-alert', rows: 5 }
-      -# %section.inline-block
-      -#   = f.label :video_url
-      -#   = f.text_field :video_url, class: "form-control"
-      -# %section.inline-block
-      -#   = f.label :slides_url
-      -#   = f.text_field :slides_url, class: "form-control"
+      = f.label :video_url
+      = f.text_field :video_url, class: "form-control"
+
+      = f.label :slides_url
+      = f.text_field :slides_url, class: "form-control"
     - if @program_session.new_record?
       %fieldset.col-md-6
         %h4 Speaker

--- a/app/views/staff/program_sessions/show.html.haml
+++ b/app/views/staff/program_sessions/show.html.haml
@@ -41,6 +41,12 @@
         %h3.control-label Abstract
         .markdown{ data: { 'field-id' => 'program_session_abstract' } }
           = program_session.abstract_markdown
+      .program-session-item
+        %h3.control-label Video URL
+        = link_to program_session.video_url
+      .program-session-item
+        %h3.control-label Slides URL
+        = link_to program_session.slides_url
 
     .col-md-6
       .program-session-item

--- a/app/views/staff/proposals/show.html.haml
+++ b/app/views/staff/proposals/show.html.haml
@@ -106,15 +106,6 @@
           .widget-content
             = render partial: 'shared/proposals/tags_form', locals: { event: event, proposal: proposal }
 
-          -#Gonna migrate this over to ProgramSession show page in the near future
-          -#- if proposal.proposal_data?
-          -#  %h3 Video URL
-          -#  = proposal.proposal_data[:video_url]
-          -#  %br/
-          -#
-          -#  %h3 Slides URL
-          -#  = proposal.proposal_data[:slides_url]
-
         .internal-comments
           .widget-header
             %i.fa.fa-comments

--- a/db/migrate/20160923182207_add_info_to_program_sessions.rb
+++ b/db/migrate/20160923182207_add_info_to_program_sessions.rb
@@ -1,0 +1,5 @@
+class AddInfoToProgramSessions < ActiveRecord::Migration
+  def change
+    add_column :program_sessions, :info, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -89,6 +89,7 @@ ActiveRecord::Schema.define(version: 20160927205019) do
     t.text     "state",             default: "active"
     t.datetime "created_at",                           null: false
     t.datetime "updated_at",                           null: false
+    t.text     "info"
   end
 
   add_index "program_sessions", ["event_id"], name: "index_program_sessions_on_event_id", using: :btree

--- a/spec/features/staff/organizer_manages_program_session_spec.rb
+++ b/spec/features/staff/organizer_manages_program_session_spec.rb
@@ -25,10 +25,12 @@ feature "Organizers can manage program sessions" do
     visit edit_event_staff_program_session_path(event, program_session)
 
     fill_in "Title", with: "New Session Title"
+    fill_in "Video url", with: "http://www.youtube.com"
     click_on "Save"
 
     expect(current_path).to eq(event_staff_program_session_path(event, program_session))
     expect(page).to have_content("New Session Title")
+    expect(page).to have_link("http://www.youtube.com")
   end
 
   scenario "organizer can add speaker to program session" do


### PR DESCRIPTION
Creates info hash on program sessions for video and slide urls, adds form fields for organizers to add these items upon editing
