### PR TITLE
#186 time slots

### DIFF
--- a/app/assets/javascripts/staff/program/time-slot.js
+++ b/app/assets/javascripts/staff/program/time-slot.js
@@ -1,6 +1,5 @@
 $(document).ready(function() {
   initTimeSlotsTable();
-  initTimeSlotTimePickers();
 });
 
 function initTimeSlotsTable() {
@@ -10,38 +9,42 @@ function initTimeSlotsTable() {
 }
 
 function initTimeSlotTimePickers() {
-  $('#time-slot-start-time, #time-slot-end-time').timepicker({
+  $('#time_slot_start_time, #time_slot_end_time').timepicker({
       timeFormat: 'HH:mm'
   });
 }
 
-function setUpTimeSlotDialog(dialog) {
-  dialog.find('#cancel').click(function(e) {
-    dialog.empty();
-    dialog.modal('hide');
-    return false;
-  });
-
+function setUpTimeSlotDialog($dialog) {
   initTimeSlotTimePickers();
 
-  var proposalSelect = $('#session_proposal_id');
-  var fields = $('#session_title, #session_presenter, #session_description');
+  $(document).on('change', '.available-proposals', onSessionSelectChange);
 
-  var toggleFields = function() {
-    if (proposalSelect.val() === '') {
-      fields.prop('disabled', false);
-    } else {
-      fields.prop('disabled', true);
+  updateInfoFields($dialog.find('.available-proposals'));
+
+  function updateInfoFields($select) {
+    var $form = $select.closest('form');
+    var $fields = $form.find('.supplemental-fields');
+    var $info = $form.find('.selected-session-info');
+
+    var data = $select.find(':selected').data();
+    if (data) {
+      $info.find('.speaker').html(data['speaker']);
+      $info.find('.abstract').html(data['abstract']);
+      $info.find('.confirmation-notes').html(data['confirmationNotes']);
     }
-  };
 
-  proposalSelect.change(function() {
-    toggleFields();
-    var notes = $(this).find(':selected').data('confirmation-notes');
-    $('#confirmation-notes').text(notes);
-  });
+    if ($select.val() === '') {
+      $fields.show();
+      $info.hide();
+    } else {
+      $fields.hide();
+      $info.show();
+    }
+  }
 
-  toggleFields();
+  function onSessionSelectChange(ev) {
+    updateInfoFields($(this));
+  }
 }
 
 function clearFields(fields, opt_parent) {
@@ -59,7 +62,7 @@ function clearFields(fields, opt_parent) {
   }
 }
 
-function renderTimeSlots(html) {
+function renderTimeSlots(html) { // currently unused
   $('#time_slots').html(html);
   initTimeSlotsTable();
 }

--- a/app/assets/stylesheets/modules/_events.scss
+++ b/app/assets/stylesheets/modules/_events.scss
@@ -50,15 +50,6 @@
     border: 1px solid transparent;
     border-radius: 4px;
   }
-
-  #config-modal {
-    .errors {
-      background-color: #edd1d1;
-      color: darken(#edd1d1, 50%);
-      border-radius: .25em;
-      padding-left: .25em;
-    }
-  }
 }
 
 .event-info-bar {

--- a/app/assets/stylesheets/modules/_time-slot.scss
+++ b/app/assets/stylesheets/modules/_time-slot.scss
@@ -3,14 +3,9 @@
   background-color: #f2dede;
 }
 
-.time-slot-edit-dialog {
-  form {
-    text-align: left;
-
-    .form-group {
-      display: block;
-      margin-bottom: 15px;
-    }
+#staff_time_slots_index {
+  .form-inline {
+    margin-bottom: 15px;
   }
 }
 
@@ -29,7 +24,7 @@
   }
 }
 
-#room-new-dialog {
+.modal-dialog {
   .errors {
     background-color: #edd1d1;
     color: darken(#edd1d1, 50%);

--- a/app/controllers/staff/schedules_controller.rb
+++ b/app/controllers/staff/schedules_controller.rb
@@ -1,10 +1,10 @@
 class Staff::SchedulesController < Staff::ApplicationController
-  decorates_assigned :time_slots
+  decorates_assigned :time_slots, with: Staff::TimeSlotDecorator
 
   protected
 
   def set_time_slots
-    @time_slots =
-      @event.time_slots.includes(:room, program_session: { proposal: {speakers: :user }})
+    @time_slots = current_event.time_slots
+                      .includes(:room, program_session: { proposal: {speakers: :user }})
   end
 end

--- a/app/controllers/staff/time_slots_controller.rb
+++ b/app/controllers/staff/time_slots_controller.rb
@@ -1,27 +1,12 @@
 class Staff::TimeSlotsController < Staff::SchedulesController
 
-  before_action :set_time_slot, only: [:update, :destroy, :edit ]
+  before_action :set_time_slot, only: [:edit, :update, :destroy]
   before_action :set_time_slots, only: :index
 
-  helper_method :time_slot_decorator
-
-  def new
-    if session[:sticky_time_slot]
-      @time_slot = @event.time_slots.build(session[:sticky_time_slot])
-      @event = @event.decorate
-    else
-      date = DateTime.now.beginning_of_hour
-      @time_slot = @event.time_slots.build(start_time: date, end_time: date)
-      @event = @event.decorate
-    end
-
-    respond_to do |format|
-      format.js
-    end
-  end
+  helper_method :time_slot_decorated
 
   def index
-    @rooms = @event.rooms.by_grid_position
+    @rooms = current_event.rooms.by_grid_position
     respond_to do |format|
       format.html
       format.csv { send_data time_slots.to_csv }
@@ -29,10 +14,23 @@ class Staff::TimeSlotsController < Staff::SchedulesController
     end
   end
 
+  def new
+    if session[:sticky_time_slot]
+      @time_slot = current_event.time_slots.build(session[:sticky_time_slot])
+    else
+      date = DateTime.current.beginning_of_hour
+      @time_slot = current_event.time_slots.build(start_time: date, end_time: date)
+    end
+
+    respond_to do |format|
+      format.js
+    end
+  end
+
   def create
     save_and_add = params[:button] == 'save_and_add'
 
-    @time_slot = @event.time_slots.build(time_slot_params)
+    @time_slot = current_event.time_slots.build(time_slot_params)
 
     f = save_and_add ? flash : flash.now
     if @time_slot.save
@@ -45,7 +43,7 @@ class Staff::TimeSlotsController < Staff::SchedulesController
         room_id: @time_slot.room ? @time_slot.room.id : nil
       }
     else
-      f[:warning] = "There was a problem creating this time slot."
+      f[:danger] = "There was a problem creating this time slot."
     end
 
     respond_to do |format|
@@ -59,8 +57,11 @@ class Staff::TimeSlotsController < Staff::SchedulesController
   end
 
   def update
-    @time_slot.update_attributes(time_slot_params)
-    flash.now[:info] = "Time slot updated."
+    if @time_slot.update_attributes(time_slot_params)
+      flash.now[:info] = "Time slot updated."
+    else
+      flash.now[:danger] = "There was a problem saving this time slot."
+    end
 
     respond_to do |format|
       format.js
@@ -84,10 +85,10 @@ private
   end
 
   def set_time_slot
-    @time_slot = TimeSlot.find(params[:id])
+    @time_slot = current_event.time_slots.find(params[:id])
   end
 
-  def time_slot_decorator
-    @time_slot_decorator ||= @time_slot.decorate
+  def time_slot_decorated
+    @time_slot_decorated ||= Staff::TimeSlotDecorator.decorate(@time_slot)
   end
 end

--- a/app/decorators/staff/program_session_decorator.rb
+++ b/app/decorators/staff/program_session_decorator.rb
@@ -15,7 +15,7 @@ class Staff::ProgramSessionDecorator < ApplicationDecorator
   end
 
   def session_format_name
-    session_format.name
+    object.session_format.try(:name)
   end
 
   def state_label(large: false, state: nil)
@@ -44,7 +44,10 @@ class Staff::ProgramSessionDecorator < ApplicationDecorator
     h.markdown(object.abstract)
   end
 
-  def scheduled?
-    time_slot.present?
+  def scheduled_for
+    day = object.time_slot.conference_day
+    from = object.time_slot.start_time.to_s(:time)
+    to = object.time_slot.end_time.to_s(:time)
+    "Day #{day}, #{from} - #{to}"
   end
 end

--- a/app/decorators/staff/time_slots_decorator.rb
+++ b/app/decorators/staff/time_slots_decorator.rb
@@ -1,4 +1,4 @@
-class TimeSlotsDecorator < Draper::CollectionDecorator
+class Staff::TimeSlotsDecorator < Draper::CollectionDecorator
   def to_csv
     CSV.generate do |csv|
       columns = [ :conference_day, :start_time, :end_time, :title,

--- a/app/helpers/time_slot_helper.rb
+++ b/app/helpers/time_slot_helper.rb
@@ -1,16 +1,4 @@
 module TimeSlotHelper
-  def track_options(time_slot)
-    selected = time_slot.track_id
-
-    options_from_collection_for_select(@event.tracks.all, :id, :name, selected)
-  end
-
-  def room_options(time_slot)
-    selected = time_slot.try(:room).try(:id)
-
-    options_from_collection_for_select(@event.rooms.all, :id, :name, selected)
-  end
-
   def unmet_requirements(event)
     @_unmet_requirements ||= event.unmet_requirements_for_scheduling.map do |msg|
       content_tag :li, msg, class: 'list-group-item custom-list-group-item-danger'

--- a/app/models/program_session.rb
+++ b/app/models/program_session.rb
@@ -67,6 +67,10 @@ class ProgramSession < ActiveRecord::Base
     proposal.try(:confirmation_notes)
   end
 
+  def scheduled?
+    time_slot.present?
+  end
+
   private
 
   def destroy_speakers

--- a/app/models/time_slot.rb
+++ b/app/models/time_slot.rb
@@ -5,6 +5,8 @@ class TimeSlot < ActiveRecord::Base
 
   STANDARD_LENGTH = 40.minutes
 
+  before_save :clear_fields_if_session
+
   scope :day, -> (num) { where(conference_day: num).order(:start_time).order(room_name: :asc) }
   scope :start_times_by_day, -> (num) { day(num+1).pluck(:start_time).uniq }
   scope :by_room, -> do
@@ -18,6 +20,14 @@ class TimeSlot < ActiveRecord::Base
       slot.delete("session_id")
       slot.delete("desc")
       self.create!(slot)
+    end
+  end
+
+  def clear_fields_if_session
+    if program_session
+      self.title = ''
+      self.presenter = ''
+      self.description = ''
     end
   end
 

--- a/app/views/shared/schedule/_days.html.haml
+++ b/app/views/shared/schedule/_days.html.haml
@@ -15,7 +15,7 @@
           %p
             = row_time(conf_slot)
         - if conf_slot.conference_wide?
-          - ts = conf_slot.conference_wide_session.decorate
+          - ts = Staff::TimeSlotDecorator.decorate(conf_slot.conference_wide_session)
           %td.proposal-slot.time-slot{ colspan: @rooms.count, data: ts.cell_data_attr}
             %p
               = ts.conference_wide_title
@@ -24,14 +24,14 @@
             - if conference_day.session_empty?(ts, i, conf_slot)
               %td
             - elsif ts.present?
-              - ts = ts.decorate
+              - ts = Staff::TimeSlotDecorator.decorate(ts)
               - takes_two = ts.takes_two_time_slots?
               %td.time-slot{rowspan: (2 if takes_two), data: ts.cell_data_attr}
                 .session-content
                   %p.session-title
-                    = ts.title
+                    = ts.display_title
                   %p.speaker-name
-                    = ts.presenter
+                    = ts.display_presenter
 
 
 

--- a/app/views/staff/program_sessions/_session_row_active.html.haml
+++ b/app/views/staff/program_sessions/_session_row_active.html.haml
@@ -3,6 +3,6 @@
       event_staff_program_session_path(program_session.event, program_session))
   %td= program_session.speakers.map { |speaker| link_to speaker.name, event_staff_program_speaker_path(program_session.event, speaker) }.join(", ").html_safe
   %td= program_session.track_name
-  %td= program_session.scheduled? ? '✓' : ''
+  %td= program_session.scheduled? ? program_session.scheduled_for : ''
   %td= program_session.state
   -#truncate(program_session.confirmation_notes, :length => 100)

--- a/app/views/staff/rooms/_form.html.haml
+++ b/app/views/staff/rooms/_form.html.haml
@@ -1,14 +1,8 @@
-= simple_form_for [ event, :staff, room ], remote: true do |f|
-  .modal-body
-    .form-inline
-      = f.input :name, placeholder: 'ex: Crab Tree Suite', autofocus: true
-      = f.input :capacity, placeholder: "ex: 300"
-      = f.input :grid_position, placeholder: "ex: 1 (use nil if room should not appear)"
-    = f.input :address, placeholder: "ex: 2500 Pleasant St. Orlando, FL 90080"
-    .form-inline
-      = f.input :room_number, placeholder: "ex: 1234 suite 3"
-      = f.input :level, placeholder: "ex: level 3"
-  .modal-footer
-    .btn-toolbar
-      %button.pull-right.btn.btn-primary{:type => "submit"} Save
-      %button.btn.btn-default{"data-dismiss" => "modal"} Cancel
+.form-inline
+  = f.input :name, placeholder: 'ex: Crab Tree Suite', autofocus: true
+  = f.input :capacity, placeholder: "ex: 300"
+  = f.input :grid_position, placeholder: "ex: 1 (use nil if room should not appear)"
+= f.input :address, placeholder: "ex: 2500 Pleasant St. Orlando, FL 90080"
+.form-inline
+  = f.input :room_number, placeholder: "ex: 1234 suite 3"
+  = f.input :level, placeholder: "ex: level 3"

--- a/app/views/staff/rooms/_room.html.haml
+++ b/app/views/staff/rooms/_room.html.haml
@@ -18,6 +18,13 @@
     %div{ id: "room-edit-#{room.id}", class: 'modal fade' }
       .modal-dialog
         .modal-content
-          .modal-header
-            %h3 Edit Room
-          = render partial: 'staff/rooms/form', locals: { room: room }
+          = simple_form_for [ event, :staff, room ], remote: true do |f|
+            .modal-header
+              %h3 Edit Room
+              .errors
+            .modal-body
+              = render partial: 'staff/rooms/form', locals: { room: room, f: f }
+            .modal-footer
+              .btn-toolbar
+                %button.pull-right.btn.btn-primary{:type => "submit"} Save
+                %button.btn.btn-default{"data-dismiss" => "modal"} Cancel

--- a/app/views/staff/rooms/destroy.js.erb
+++ b/app/views/staff/rooms/destroy.js.erb
@@ -2,8 +2,8 @@ $('table#organizer-rooms #room_<%= room.id %>').remove();
 reloadTimeSlotsTable(<%=raw time_slots.rows.to_json %>);
 
 <% if has_missing_requirements?(room.event) %>
-  $('#time-slot-prereqs').removeClass('hidden')
-  $('#add-time-slot').addClass('disabled')
+  $('#time-slot-prereqs').removeClass('hidden');
+  $('#add-time-slot').addClass('disabled');
 
   document.getElementById('missing-prereq-messages').innerHTML =
     '<%=j unmet_requirements(room.event) %>';

--- a/app/views/staff/rooms/update.js.erb
+++ b/app/views/staff/rooms/update.js.erb
@@ -1,5 +1,7 @@
+$("#room-edit-<%= room.id %> .errors").html("");
+
 <% if @room.errors.present? %>
-  $("#room-new-dialog .errors").append("<%= @room.errors.full_messages.join(', ') %>");
+  $("#room-edit-<%= room.id %> .errors").append("<%= @room.errors.full_messages.join(', ') %>");
 <% else %>
   $("#room-edit-<%= room.id %>").modal("hide");
 

--- a/app/views/staff/time_slots/_edit_dialog.html.haml
+++ b/app/views/staff/time_slots/_edit_dialog.html.haml
@@ -1,9 +1,10 @@
 %div{ id: "time-slot-edit-#{time_slot.id}" }
   .modal-dialog
     .modal-content
-      = form_for [event, time_slot], url: event_staff_time_slot_path(time_slot.event, time_slot), remote: true, html: {role: 'form'} do |f|
+      = simple_form_for [event, :staff, time_slot], url: event_staff_time_slot_path(time_slot.event, time_slot), remote: true, html: {role: 'form'} do |f|
         .modal-header
           %h3 Edit Time Slot
+          .errors
         .modal-body
           = render partial: 'staff/time_slots/form',
               locals: {f: f, time_slot: time_slot }

--- a/app/views/staff/time_slots/_form.html.haml
+++ b/app/views/staff/time_slots/_form.html.haml
@@ -1,33 +1,24 @@
-.form-group
-  = f.label :conference_day
-  = f.select :conference_day, event.days_for,  class: 'form-control', placeholder: ''
-.form-group
-  = f.label :start_time
-  = f.text_field :start_time, class: 'form-control', value: time_slot.start_time
-.form-group
-  = f.label :end_time
-  = f.text_field :end_time, class: 'form-control', value: time_slot.end_time
-.form-group
-  = f.label :room_id
-  = f.select :room_id, room_options(time_slot), { include_blank: true }, class: 'form-control', placeholder: ''
-.form-group
-  = f.label :track_id
-  = f.select :track_id, track_options(time_slot), { include_blank: true }, class: 'form-control', placeholder: ''
-.form-group
-  = f.label :program_session_id
-  = f.select :program_session_id, time_slot.unscheduled_program_sessions,
-      { include_blank: true },
-      class: 'form-control available-proposals', placeholder: ''
-  %p#confirmation-notes.help-block
-    = time_slot.proposal_confirm_notes
+.form-inline
+  = f.input :conference_day, collection: event.days_for, label: 'Day'
+  = f.input :room_id, collection: current_event.rooms, include_blank: true
+.form-inline
+  = f.input :start_time, as: :string, input_html: { value: time_slot.start_time }
+  = f.input :end_time, as: :string, input_html: { value: time_slot.end_time }
+-#= f.input :track_id, collection: current_event.tracks, include_blank: true
+= f.input :program_session_id, collection: time_slot.unscheduled_program_sessions, include_blank: true,
+  input_html: { class: 'available-proposals' }
+.selected-session-info
+  .session-meta-item
+    %strong Presenter:
+    %p.speaker= time_slot.display_presenter
+  .session-meta-item
+    %strong Abstract:
+    %p.abstract= time_slot.display_description
+  .session-meta-item
+    %strong Confirmation Notes:
+    %p.confirmation-notes= time_slot.session_confirmation_notes
 
-%fieldset#time-slot-description
-  .form-group
-    = f.label :title
-    = f.text_field :title, class: 'form-control', placeholder: ''
-  .form-group
-    = f.label :presenter
-    = f.text_field :presenter, class: 'form-control', placeholder: ''
-  .form-group
-    = f.label :description
-    = f.text_area :description, class: 'form-control', placeholder: ''
+%fieldset.supplemental-fields{class: time_slot.supplemental_fields_visibility_css }
+  = f.input :title, as: :string
+  = f.input :presenter, as: :string
+  = f.input :description, as: :text

--- a/app/views/staff/time_slots/_new_dialog.html.haml
+++ b/app/views/staff/time_slots/_new_dialog.html.haml
@@ -1,10 +1,9 @@
 .modal-dialog
   .modal-content
-    = form_for [event, time_slot], remote: true,
-        url: event_staff_time_slots_path(event),
-        html: {role: 'form'} do |f|
+    = simple_form_for [current_event, :staff, time_slot], remote: true, html: {role: 'form'} do |f|
       .modal-header
         %h3 New Time Slot
+        .errors
       .modal-body
         = render partial: 'staff/time_slots/form',
             locals: {f: f, time_slot: time_slot}

--- a/app/views/staff/time_slots/_rooms.html.haml
+++ b/app/views/staff/time_slots/_rooms.html.haml
@@ -23,7 +23,13 @@
       #room-new-dialog.modal.fade
         .modal-dialog
           .modal-content
-            .modal-header
-              %h3 New Room
-              .errors
-            = render partial: "staff/rooms/form", locals: { room: Room.new }
+            = simple_form_for [ event, :staff, Room.new ], remote: true do |f|
+              .modal-header
+                %h3 New Room
+                .errors
+              .modal-body
+                = render partial: "staff/rooms/form", locals: { f: f }
+              .modal-footer
+                .btn-toolbar
+                  %button.pull-right.btn.btn-primary{:type => "submit"} Save
+                  %button.btn.btn-default{"data-dismiss" => "modal"} Cancel

--- a/app/views/staff/time_slots/_time_slots.html.haml
+++ b/app/views/staff/time_slots/_time_slots.html.haml
@@ -41,7 +41,6 @@
             %th
             %th
             %th
-            %th
           %tr
             %th Conference Day
             %th Start Time
@@ -50,7 +49,6 @@
             %th Presenter
             %th Room
             %th Track
-            %th ID
             %th.actions Actions
         %tbody
           - time_slots.each do |slot|

--- a/app/views/staff/time_slots/create.js.erb
+++ b/app/views/staff/time_slots/create.js.erb
@@ -1,7 +1,20 @@
-<% if save_and_add %>
-  $('#add-time-slot').click();
+$("#time-slot-new-dialog .errors").html("");
+
+<% if @time_slot.persisted? %>
+  <% if local_assigns[:save_and_add] %>
+    $('#time_slot_title').val('');
+    $('#time_slot_presenter').val('');
+    $('#time_slot_description').val('');
+    $('#time_slot_program_session_id').val('').change();
+
+  <% else %>
+    $('#time-slot-new-dialog').modal('hide');
+  <% end %>
+  addTimeSlotRow(<%=raw time_slot_decorated.row.to_json %>);
+
 <% else %>
-  $('#time-slot-new-dialog').modal('hide');
+  $("#time-slot-new-dialog .errors").html("<%= @time_slot.errors.full_messages.join(', ') %>");
 <% end %>
 
-addTimeSlotRow(<%=raw time_slot_decorator.row.to_json %>);
+document.getElementById("flash").innerHTML = "<%=j show_flash %>";
+$("html, body").animate({ scrollTop: 0 }, "slow");

--- a/app/views/staff/time_slots/destroy.js.erb
+++ b/app/views/staff/time_slots/destroy.js.erb
@@ -1,3 +1,6 @@
 var table = $('#organizer-time-slots.datatable').dataTable();
 
 table.fnDeleteRow($('table#organizer-time-slots #time_slot_<%= time_slot_id %>')[0]);
+
+document.getElementById("flash").innerHTML = "<%=j show_flash %>";
+$("html, body").animate({ scrollTop: 0 }, "slow");

--- a/app/views/staff/time_slots/edit.js.erb
+++ b/app/views/staff/time_slots/edit.js.erb
@@ -2,6 +2,6 @@ var editDialog = $('#time-slot-edit-dialog');
 
 editDialog[0].innerHTML =
     '<%=j render partial: 'edit_dialog',
-      locals: { time_slot: time_slot_decorator, event: event } %>';
+      locals: { time_slot: time_slot_decorated, event: event } %>';
 
 setUpTimeSlotDialog(editDialog);

--- a/app/views/staff/time_slots/new.js.erb
+++ b/app/views/staff/time_slots/new.js.erb
@@ -1,7 +1,7 @@
 var newDialog = $('#time-slot-new-dialog');
 
 newDialog[0].innerHTML =
-  '<%=j render partial: 'new_dialog', locals: { time_slot: time_slot_decorator, event: event } %>';
+  '<%=j render partial: 'new_dialog', locals: { time_slot: time_slot_decorated, event: event } %>';
 
 setUpTimeSlotDialog(newDialog);
 

--- a/app/views/staff/time_slots/update.js.erb
+++ b/app/views/staff/time_slots/update.js.erb
@@ -1,13 +1,22 @@
-$('#time-slot-edit-dialog').modal('hide');
+$("#time-slot-edit-dialog .errors").html("");
 
-var table = $('#organizer-time-slots.datatable').dataTable();
-var row = $('table#organizer-time-slots #time_slot_<%= time_slot_decorator.id %>')[0];
+<% if @time_slot.errors.present? %>
+$("#time-slot-edit-dialog .errors").html("<%= @time_slot.errors.full_messages.join(', ') %>");
+<% else %>
+  $('#time-slot-edit-dialog').modal('hide');
 
-var data = <%=raw time_slot_decorator.row_data.to_json %>;
+  var table = $('#organizer-time-slots.datatable').dataTable();
+  var row = $('table#organizer-time-slots #time_slot_<%= time_slot_decorated.id %>')[0];
 
-<%# To avoid having to re-add the 'actions' cell we have to add the data %>
-<%# one column at a time %>
-var length = data.length;
-for (var i = 0; i < length; ++i) {
-  table.fnUpdate(data[i], row, i);
-}
+  var data = <%=raw time_slot_decorated.row_data.to_json %>;
+
+  <%# To avoid having to re-add the 'actions' cell we have to add the data %>
+  <%# one column at a time %>
+  var length = data.length;
+  for (var i = 0; i < length; ++i) {
+    table.fnUpdate(data[i], row, i);
+  }
+<% end %>
+
+document.getElementById("flash").innerHTML = "<%=j show_flash %>";
+$("html, body").animate({ scrollTop: 0 }, "slow");

--- a/spec/decorators/staff/time_slot_decorator_spec.rb
+++ b/spec/decorators/staff/time_slot_decorator_spec.rb
@@ -1,17 +1,17 @@
 require 'rails_helper'
 
-describe TimeSlotDecorator do
+describe Staff::TimeSlotDecorator do
   describe '#row_data' do
     it 'returns a link to the proposal in the title' do
       time_slot = FactoryGirl.create(:time_slot_with_program_session)
-      path = h.event_staff_proposal_path(time_slot.event, time_slot.program_session.proposal)
-      data = time_slot.decorate.row_data
+      path = h.event_staff_program_session_path(time_slot.event, time_slot.program_session)
+      data = Staff::TimeSlotDecorator.decorate(time_slot).row_data
       expect(data[3]).to match(path)
     end
 
     it 'returns the title if there is no program session' do
       time_slot = FactoryGirl.create(:time_slot)
-      data = time_slot.decorate.row_data
+      data = Staff::TimeSlotDecorator.decorate(time_slot).row_data
       expect(data[3]).to eq(time_slot.title)
     end
   end

--- a/spec/decorators/staff/time_slots_decorator_spec.rb
+++ b/spec/decorators/staff/time_slots_decorator_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+describe Staff::TimeSlotsDecorator do
+end

--- a/spec/decorators/time_slots_decorator_spec.rb
+++ b/spec/decorators/time_slots_decorator_spec.rb
@@ -1,4 +1,0 @@
-require 'rails_helper'
-
-describe TimeSlotsDecorator do
-end


### PR DESCRIPTION
Organizers Can Manage Time Slots
- Fixed bug on create new.
- Fixed timepickers.
- Fixed sticky form values.
- Refactored form for compactness.
- Form toggles between display-only session values and time slot fields depending on whether session is selected.
- Moved TimeSlot decorators into Staff namespace.
- Partially repaired save_and_add flow.
- Show scheduled time for session on session index.
