### PR TITLE
#189 Organizers can download schedule JSON

### DIFF
--- a/app/assets/javascripts/staff/program/time-slot.js
+++ b/app/assets/javascripts/staff/program/time-slot.js
@@ -28,6 +28,8 @@ function setUpTimeSlotDialog($dialog) {
 
     var data = $select.find(':selected').data();
     if (data) {
+      $info.find('.title').html(data['title']);
+      $info.find('.track').html(data['track']);
       $info.find('.speaker').html(data['speaker']);
       $info.find('.abstract').html(data['abstract']);
       $info.find('.confirmation-notes').html(data['confirmationNotes']);

--- a/app/assets/stylesheets/modules/_time-slot.scss
+++ b/app/assets/stylesheets/modules/_time-slot.scss
@@ -24,6 +24,12 @@
   }
 }
 
+#organizer-time-slots {
+  td:last-child {
+    white-space: nowrap;
+  }
+}
+
 .modal-dialog {
   .errors {
     background-color: #edd1d1;

--- a/app/controllers/staff/time_slots_controller.rb
+++ b/app/controllers/staff/time_slots_controller.rb
@@ -81,7 +81,7 @@ class Staff::TimeSlotsController < Staff::SchedulesController
 private
 
   def time_slot_params
-    params.require(:time_slot).permit(:conference_day, :start_time, :end_time, :title, :description, :presenter, :room_id, :program_session_id)
+    params.require(:time_slot).permit(:conference_day, :room_id, :start_time, :end_time, :program_session_id, :title, :track_id, :presenter, :description)
   end
 
   def set_time_slot

--- a/app/decorators/staff/time_slot_decorator.rb
+++ b/app/decorators/staff/time_slot_decorator.rb
@@ -52,6 +52,8 @@ class Staff::TimeSlotDecorator < Draper::Decorator
 
     program_sessions.map do |ps|
       [ps.title, ps.id, { selected: ps == object.program_session, data: {
+          'title' => ps.title,
+          'track' => ps.track.try(:name),
           'speaker' => speaker_names(ps),
           'abstract' => ps.abstract,
           'confirmation-notes' => ps.proposal.try(:confirmation_notes) || ''
@@ -63,14 +65,6 @@ class Staff::TimeSlotDecorator < Draper::Decorator
     object.program_session.try(:proposal).try(:confirmation_notes)
   end
 
-  def display_title
-    if object.program_session.present?
-      object.program_session.title
-    else
-      object.title
-    end
-  end
-
   def linked_title
     if object.program_session.present?
       h.link_to(object.program_session.title,
@@ -80,32 +74,28 @@ class Staff::TimeSlotDecorator < Draper::Decorator
     end
   end
 
+  def display_title
+    object.program_session && object.program_session.title || object.title
+  end
+
   def display_presenter
-    if object.program_session.present?
-      speaker_names(object.program_session)
-    else
-      object.presenter
-    end
+    object.program_session && speaker_names(object.program_session) || object.presenter
   end
 
   def display_description
-    if object.program_session.present?
-      object.program_session.try(:abstract)
-    else
-      object.description
-    end
-  end
-
-  def track_id
-    object.program_session.try(:track_id)
+    object.program_session && object.program_session.abstract || object.description
   end
 
   def track_name
-    object.program_session.try(:track).try(:name)
+    object.program_session && object.program_session.track.try(:name) || object.track.try(:name)
+  end
+
+  def track_id
+    object.program_session && object.program_session.track_id || object.track_id
   end
 
   def room_name
-    object.try(:room).try(:name)
+    object.room.try(:name)
   end
 
   def conference_wide_title

--- a/app/models/time_slot.rb
+++ b/app/models/time_slot.rb
@@ -1,6 +1,7 @@
 class TimeSlot < ActiveRecord::Base
   belongs_to :program_session
   belongs_to :room
+  belongs_to :track
   belongs_to :event
 
   STANDARD_LENGTH = 40.minutes
@@ -23,28 +24,21 @@ class TimeSlot < ActiveRecord::Base
     end
   end
 
+  def self.track_names
+    pluck(:track_name).uniq
+  end
+
   def clear_fields_if_session
     if program_session
       self.title = ''
       self.presenter = ''
       self.description = ''
+      self.track_id
     end
-  end
-
-  def self.track_names
-    pluck(:track_name).uniq
   end
 
   def takes_two_time_slots?
     (end_time - start_time) > STANDARD_LENGTH
-  end
-
-  def desc
-    if program_session
-      program_session.abstract
-    else
-      description
-    end
   end
 
 end
@@ -65,6 +59,7 @@ end
 #  presenter          :text
 #  created_at         :datetime
 #  updated_at         :datetime
+#  track_id           :integer
 #
 # Indexes
 #

--- a/app/serializers/time_slot_serializer.rb
+++ b/app/serializers/time_slot_serializer.rb
@@ -1,4 +1,26 @@
 class TimeSlotSerializer < ActiveModel::Serializer
-  attributes :conference_day, :start_time, :end_time, :session_id, :program_session_id, :title, :presenter,
-    :room_name, :track_name, :desc
+  attributes :conference_day, :start_time, :end_time, :program_session_id, :title, :presenter,
+    :room, :track, :description
+
+  #NOTE: object references a TimeSlotDecorator
+
+  def room
+    object.room_name
+  end
+
+  def track
+    object.track_name
+  end
+
+  def title
+    object.display_title
+  end
+
+  def presenter
+    object.display_presenter
+  end
+
+  def description
+    object.display_description
+  end
 end

--- a/app/views/staff/program_sessions/_form.html.haml
+++ b/app/views/staff/program_sessions/_form.html.haml
@@ -4,7 +4,7 @@
       = f.input :title, maxlength: 60, input_html: { class: 'watched js-maxlength-alert', rows: 1 }
       = f.association :session_format, as: :select, collection: current_event.session_formats, label: "Format",
         include_blank: false, required: true
-      = f.association :track, as: :select, collection: current_event.tracks, label: "Track"
+      = f.association :track, as: :select, collection: current_event.tracks, label: "Track", include_blank: true
       - unless @program_session.new_record?
         = f.input :state, as: :select, collection: session_states_collection, label: "State",
           include_blank: false, required: true

--- a/app/views/staff/time_slots/_form.html.haml
+++ b/app/views/staff/time_slots/_form.html.haml
@@ -9,6 +9,12 @@
   input_html: { class: 'available-proposals' }
 .selected-session-info
   .session-meta-item
+    %strong Title:
+    %p.title= time_slot.display_title
+  .session-meta-item
+    %strong Track:
+    %p.track= time_slot.track_name
+  .session-meta-item
     %strong Presenter:
     %p.speaker= time_slot.display_presenter
   .session-meta-item
@@ -20,5 +26,6 @@
 
 %fieldset.supplemental-fields{class: time_slot.supplemental_fields_visibility_css }
   = f.input :title, as: :string
+  = f.association :track, as: :select, collection: current_event.tracks, include_blank: true
   = f.input :presenter, as: :string
   = f.input :description, as: :text

--- a/db/migrate/20160927205019_add_time_slot_track.rb
+++ b/db/migrate/20160927205019_add_time_slot_track.rb
@@ -1,0 +1,5 @@
+class AddTimeSlotTrack < ActiveRecord::Migration
+  def change
+    add_reference :time_slots, :track
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160804194731) do
+ActiveRecord::Schema.define(version: 20160927205019) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -215,6 +215,7 @@ ActiveRecord::Schema.define(version: 20160804194731) do
     t.text     "presenter"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.integer  "track_id"
   end
 
   add_index "time_slots", ["conference_day"], name: "index_time_slots_on_conference_day", using: :btree


### PR DESCRIPTION
- Updated TimeSlotSerializer to reflect recent schema changes.
- Added track_id back to the time_slots table.
