### PR TITLE
#207 Proposal Status

### DIFF
--- a/app/controllers/staff/proposals_controller.rb
+++ b/app/controllers/staff/proposals_controller.rb
@@ -26,7 +26,7 @@ class Staff::ProposalsController < Staff::ApplicationController
 
   def update_state
     if @proposal.finalized?
-      authorize @proposal, :update_finalized_state?
+      authorize @proposal, :finalize?
     else
       authorize @proposal, :update_state?
     end
@@ -67,7 +67,7 @@ class Staff::ProposalsController < Staff::ApplicationController
   end
 
   def finalize
-    authorize @proposal
+    authorize @proposal, :finalize?
 
     @proposal.finalize
     send_state_mail(@proposal.state)
@@ -75,7 +75,7 @@ class Staff::ProposalsController < Staff::ApplicationController
   end
 
   def confirm_for_speaker
-    authorize @proposal
+    authorize @proposal, :finalize?
 
     if @proposal.confirm
       flash[:success] = "Proposal confirmed for #{@proposal.event.name}."

--- a/app/controllers/staff/proposals_controller.rb
+++ b/app/controllers/staff/proposals_controller.rb
@@ -25,7 +25,11 @@ class Staff::ProposalsController < Staff::ApplicationController
   end
 
   def update_state
-    authorize @proposal
+    if @proposal.finalized?
+      authorize @proposal, :update_finalized_state?
+    else
+      authorize @proposal, :update_state?
+    end
 
     @proposal.update_state(params[:new_state])
 

--- a/app/decorators/staff/proposal_decorator.rb
+++ b/app/decorators/staff/proposal_decorator.rb
@@ -9,30 +9,29 @@ class Staff::ProposalDecorator < ProposalDecorator
     end
   end
 
-  def state_buttons(states: nil, show_finalize: true, small: false)
+  def state_buttons(states: nil, show_finalize: true, show_confirm_for_speaker: false, small: false)
     btns = buttons.map do |text, state, btn_type, hidden|
       if states.nil? || states.include?(state)
-        state_button text,
-          update_state_path(state),
+        state_button(text, update_state_path(state),
           hidden: hidden,
           type: btn_type,
-          small: small
+          small: small)
       end
     end
 
-    btns << finalize_state_button if show_finalize && h.policy(proposal).finalize?
+    btns << reset_state_button
+    btns << finalize_state_button if show_finalize
+    btns << confirm_for_speaker_button if show_confirm_for_speaker
 
     btns.join("\n").html_safe
   end
 
   def small_state_buttons
-    unless proposal.finalized?
-      state_buttons(
-          states: [ SOFT_ACCEPTED, SOFT_WAITLISTED, SOFT_REJECTED, SUBMITTED ],
-          show_finalize: false,
-          small: true
-      )
-    end
+    state_buttons(
+        states: [ SOFT_ACCEPTED, SOFT_WAITLISTED, SOFT_REJECTED, SUBMITTED ],
+        show_finalize: false,
+        small: true
+    )
   end
 
   def title_link_for_review
@@ -98,9 +97,28 @@ class Staff::ProposalDecorator < ProposalDecorator
                      'and emails will be sent to all speakers. Are you sure you want to continue?'
                  },
                  type: 'btn-warning',
-                 hidden:  object.finalized? || object.draft?,
+                 hidden: finalize_button_hidden?,
                  remote: false,
                  id: 'finalize')
+  end
+
+  def reset_state_button
+    state_button('Reset Status', update_state_path(SUBMITTED),
+                 data: object.finalized? ? {
+                     confirm:
+                         "This proposal's status has been finalized. Proceed with status reset?"
+                 } : {},
+                 type: 'btn-default',
+                 hidden: reset_button_hidden?)
+  end
+
+  def confirm_for_speaker_button
+    return if confirm_for_speaker_button_hidden?
+
+    h.link_to 'Confirm for Speaker',
+            h.confirm_for_speaker_event_staff_program_proposal_path(slug: proposal.event.slug, uuid: proposal),
+            method: :post,
+            class: "btn btn-primary btn-sm"
   end
 
   def update_state_path(state)
@@ -109,10 +127,22 @@ class Staff::ProposalDecorator < ProposalDecorator
 
   def buttons
     [
-      [ 'Accept', SOFT_ACCEPTED, 'btn-success', !object.draft? ],
+      [ 'Accept', SOFT_ACCEPTED, 'btn-success', !object.draft?  ],
       [ 'Waitlist', SOFT_WAITLISTED, 'btn-warning', !object.draft? ],
-      [ 'Reject', SOFT_REJECTED, 'btn-danger', !object.draft? ],
-      [ 'Reset Status', SUBMITTED, 'btn-default', object.draft? || object.finalized? ]
+      [ 'Reject', SOFT_REJECTED, 'btn-danger', !object.draft? ]
     ]
+  end
+
+  def finalize_button_hidden?
+    !h.policy(object).finalize? || object.draft? || object.finalized?
+  end
+
+  def reset_button_hidden?
+    object.draft? || object.confirmed? || !h.policy(proposal).update_state? ||
+      (object.finalized? && !h.policy(proposal).update_finalized_state?)
+  end
+
+  def confirm_for_speaker_button_hidden?
+    !(object.awaiting_confirmation? && h.policy(object).confirm_for_speaker?)
   end
 end

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -26,6 +26,8 @@ class Proposal < ActiveRecord::Base
   validates :abstract, length: {maximum: 625}
   validates :title, length: {maximum: 60}
   validates_inclusion_of :state, in: valid_states, allow_nil: true, message: "'%{value}' not a valid state."
+  validates_inclusion_of :state, in: FINAL_STATES, allow_nil: false, message: "'%{value}' not a confirmable state.",
+                         if: :confirmed_at_changed?
 
   serialize :last_change
   serialize :proposal_data, Hash
@@ -120,6 +122,8 @@ class Proposal < ActiveRecord::Base
       ps = ProgramSession.create_from_proposal(self)
       ps.persisted?
     end
+  rescue ActiveRecord::RecordInvalid
+    false
   end
 
   def draft?

--- a/app/policies/proposal_policy.rb
+++ b/app/policies/proposal_policy.rb
@@ -16,6 +16,10 @@ class ProposalPolicy < ApplicationPolicy
     @user.program_team_for_event?(@current_event)
   end
 
+  def update_finalized_state?
+    @user.organizer_for_event?(@current_event)
+  end
+
   def update_track?
     @user.program_team_for_event?(@current_event)
   end

--- a/app/policies/proposal_policy.rb
+++ b/app/policies/proposal_policy.rb
@@ -16,10 +16,6 @@ class ProposalPolicy < ApplicationPolicy
     @user.program_team_for_event?(@current_event)
   end
 
-  def update_finalized_state?
-    @user.organizer_for_event?(@current_event)
-  end
-
   def update_track?
     @user.program_team_for_event?(@current_event)
   end

--- a/app/views/staff/proposals/show.html.haml
+++ b/app/views/staff/proposals/show.html.haml
@@ -35,9 +35,7 @@
             .proposal-meta-item
               %strong Status:
               %span.proposal-status #{proposal.state_label(small: true)}
-            %span.state-buttons #{proposal.state_buttons}
-            - if proposal.awaiting_confirmation? && policy(proposal).confirm_for_speaker?
-              = link_to "Confirm for Speaker", confirm_for_speaker_event_staff_program_proposal_path(slug: proposal.event.slug, uuid: proposal), method: :post, class: "btn btn-primary btn-sm"
+            %span.state-buttons #{proposal.state_buttons(show_confirm_for_speaker: true)}
     .row
       .col-sm-6
         .proposal-info-bar

--- a/app/views/staff/proposals/show.html.haml
+++ b/app/views/staff/proposals/show.html.haml
@@ -35,7 +35,7 @@
             .proposal-meta-item
               %strong Status:
               %span.proposal-status #{proposal.state_label(small: true)}
-            %span.state-buttons #{proposal.state_buttons(show_confirm_for_speaker: true)}
+            %span.state-buttons #{proposal.state_buttons(show_confirm_for_speaker: true, show_hard_reset: true)}
     .row
       .col-sm-6
         .proposal-info-bar

--- a/app/views/staff/proposals/update_state.js.erb
+++ b/app/views/staff/proposals/update_state.js.erb
@@ -9,6 +9,6 @@ if ($('table.proposal-list').length > 0) {
 } else {
   <%# We are in staff/proposals/show %>
 
-  $('.state-buttons').html('<%=j proposal.state_buttons(show_finalize: false) %>');
+  $('.state-buttons').html('<%=j proposal.state_buttons(show_confirm_for_speaker: true) %>');
   $('.proposal-status').html('<%=j proposal.state_label(small: true, show_confirmed: true) %>');
 }

--- a/spec/controllers/proposals_controller_spec.rb
+++ b/spec/controllers/proposals_controller_spec.rb
@@ -64,7 +64,7 @@ describe ProposalsController, type: :controller do
 
   describe "POST #confirm" do
     it "confirms a proposal" do
-      proposal = create(:proposal, confirmed_at: nil)
+      proposal = create(:proposal, state: Proposal::ACCEPTED, confirmed_at: nil)
       allow_any_instance_of(ProposalsController).to receive(:current_user) { create(:speaker) }
       allow(controller).to receive(:require_speaker).and_return(nil)
       post :confirm, event_slug: proposal.event.slug, uuid: proposal.uuid

--- a/spec/decorators/proposal_decorator_spec.rb
+++ b/spec/decorators/proposal_decorator_spec.rb
@@ -40,7 +40,6 @@ describe ProposalDecorator do
         SUBMITTED,
         SOFT_ACCEPTED,
         SOFT_WAITLISTED,
-        SOFT_WITHDRAWN,
         SOFT_REJECTED
       ]
 

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -109,7 +109,7 @@ describe Proposal do
 
   describe "#confirmed?" do
     it "returns true if proposal has been confirmed" do
-      proposal = create(:proposal, confirmed_at: DateTime.now)
+      proposal = create(:proposal, state: Proposal::ACCEPTED, confirmed_at: DateTime.now)
       expect(proposal).to be_confirmed
     end
 

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -135,7 +135,7 @@ describe Proposal do
   describe "state changing" do
     describe "#finalized?" do
       it "returns false for all soft states" do
-        soft_states = [ SOFT_ACCEPTED, SOFT_WITHDRAWN, SOFT_WAITLISTED,
+        soft_states = [ SOFT_ACCEPTED, SOFT_WAITLISTED,
                         SOFT_REJECTED, SUBMITTED ]
 
         soft_states.each do |state|


### PR DESCRIPTION
Organizer can update proposal state (aka hard reset)

- Showing Reset Status button for finalized states. Organizer only.

- Tweaked policy to distinguish between updating state vs updating finalized states.

- Added confirm dialog for hard reset.

- Made sure correct buttons are rendered depending on state and policy.