### PR TITLE
Added free form and autosuggest to reviewer tags along with general styling of review page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'sass-rails', '~> 5.0.4'
 gem 'haml', '~> 4.0.4'
 gem 'bootstrap-sass', '~> 3.3.6'
 gem 'rails-assets-momentjs', source: 'https://rails-assets.org'
+gem 'selectize-rails'
 
 gem 'devise', '~> 4.1.1'
 gem 'omniauth-github'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -313,6 +313,7 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    selectize-rails (0.12.4)
     sexp_processor (4.6.0)
     shellany (0.0.1)
     simple_form (3.1.1)
@@ -403,6 +404,7 @@ DEPENDENCIES
   rspec
   rspec-rails
   sass-rails (~> 5.0.4)
+  selectize-rails
   simple_form (= 3.1.1)
   spring
   spring-commands-rspec

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -22,4 +22,5 @@
 //= require bootstrap-multiselect
 //= require zeroclipboard
 //= require momentjs
+//= require selectize
 //= require_tree .

--- a/app/assets/javascripts/proposal.js
+++ b/app/assets/javascripts/proposal.js
@@ -24,4 +24,31 @@ $(function() {
   $('.speaker-invite-button').click(function() {
     $('.speaker-invite-form').toggle();
   });
+
+  $('#edit-tags-icon').click(function() {
+    $('.reviewer-tags-form-wrapper').slideToggle();
+  });
+
+  if($('#autocomplete-options').length > 0) {
+    var html = $('#autocomplete-options').html();
+    var data = JSON.parse(html);
+    var items = data.map(function(x) { return { item: x }; });
+
+    $('#proposal_review_tags').selectize({
+      delimiter: ',',
+      persist: false,
+      plugins: ['remove_button'],
+      options: items,
+      valueField: 'item',
+      labelField: 'item',
+      searchField: 'item',
+      create: function(input) {
+        return {
+            value: input,
+            text: input,
+            item: input
+        }
+      }
+    });
+  }
 });

--- a/app/assets/javascripts/proposal.js
+++ b/app/assets/javascripts/proposal.js
@@ -26,7 +26,13 @@ $(function() {
   });
 
   $('#edit-tags-icon').click(function() {
-    $('.reviewer-tags-form-wrapper').slideToggle();
+    $('.proposal-reviewer-tags, #edit-tags-icon').toggle();
+    $('.review-tags-form-wrapper').slideToggle();
+  });
+
+  $('#cancel-tags-editing').click(function() {
+    $('.review-tags-form-wrapper').toggle();
+    $('.proposal-reviewer-tags, #edit-tags-icon').toggle();
   });
 
   if($('#autocomplete-options').length > 0) {

--- a/app/assets/javascripts/staff/program/subnav.js
+++ b/app/assets/javascripts/staff/program/subnav.js
@@ -31,4 +31,9 @@ $(function() {
     updateVisibility();
   }
 
+  // On-demand body padding for fixed subnav pages
+  if($('[class*="subnav"]').length > 0) {
+    var padTop = $('[class*="subnav"]').height();
+    $('body').css('padding-top', '+=' + padTop + 'px');
+  }
 });

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -28,6 +28,8 @@
 @import "dataTables/bootstrap/3/jquery.dataTables.bootstrap";
 @import "bootstrap-multiselect";
 @import "jquery-ui-timepicker-addon";
+@import "selectize";
+@import "selectize.default";
 
 // base application styles
 @import "base/mixins";

--- a/app/assets/stylesheets/base/_helper_classes.scss
+++ b/app/assets/stylesheets/base/_helper_classes.scss
@@ -20,6 +20,10 @@
   display: inline-block;
 }
 
+.inline {
+  display: inline;
+}
+
 .bg-gray-base { background-color: $gray-base; }
 .bg-gray-darker { background-color: $gray-darker; }
 .bg-gray-dark { background-color: $gray-dark; }

--- a/app/assets/stylesheets/base/_layout.scss
+++ b/app/assets/stylesheets/base/_layout.scss
@@ -1,5 +1,5 @@
 body {
-  padding-top: $navbar-height + $subnavbar-height;
+  padding-top: $navbar-height;
 
   // flexbox for sticky footer
   min-height: 100vh;

--- a/app/assets/stylesheets/base/_variables.scss
+++ b/app/assets/stylesheets/base/_variables.scss
@@ -35,8 +35,6 @@ $brand-danger:          adjust-color($dark-red, $lightness: 30%, $saturation: 30
 $brand-accent:          $gold !default;
 $brand-gray:            #ccc;
 
-
-
 //== Scaffolding
 //
 //## Settings for some of the most global styles.
@@ -413,10 +411,6 @@ $navbar-default-brand-hover-bg:            transparent !default;
 $navbar-default-toggle-hover-bg:           #ddd !default;
 $navbar-default-toggle-icon-bar-bg:        #888 !default;
 $navbar-default-toggle-border-color:       #ddd !default;
-
-//Subnav
-$subnavbar-height:                         47px;
-
 
 //=== Inverted navbar
 // Reset inverted navbar basics

--- a/app/assets/stylesheets/modules/_events.scss
+++ b/app/assets/stylesheets/modules/_events.scss
@@ -52,17 +52,8 @@
   }
 }
 
-
 .event-info-bar {
-  @media only screen and (min-width: 950px) {
-    margin-top: 20px;
-  }
-  @media only screen and (max-width: 767px) {
-    margin-top: 80px;
-  }
-  @media only screen and (max-width: 480px) {
-    margin-top: 120px;
-  }
+  margin-top: 20px;
 }
 
 .event-info {

--- a/app/assets/stylesheets/modules/_proposal.scss
+++ b/app/assets/stylesheets/modules/_proposal.scss
@@ -131,6 +131,9 @@ div.col-md-4 {
   h3 {
     display: inline-block;
   }
+  h3.comments-heading {
+    padding-left: 5px;
+  }
 }
 
 .invite-btns {
@@ -150,7 +153,7 @@ div.col-md-4 {
   margin-left: 5px;
 }
 
-.reviewer-tags-form-wrapper {
+.review-tags-form-wrapper {
   display: none;
   padding-top: 5px;
   text-align: left;
@@ -159,6 +162,12 @@ div.col-md-4 {
   }
   .form-group {
     display: inline-block;
+  }
+  .form-group.col-sm-8 {
+    padding-right: 0%;
+  }
+  .form-group.col-sm-2 {
+    padding-right: 1%;
   }
   .selectize-input.items .item {
     background: $state-success-bg;
@@ -203,7 +212,8 @@ div.col-md-4 {
         margin-bottom: 0;
       }
       .info-item-heading {
-        text-decoration: underline;
+        color: $gray;
+        font-size: $font-size-xs;
       }
     }
     .review-tags-heading {

--- a/app/assets/stylesheets/modules/_proposal.scss
+++ b/app/assets/stylesheets/modules/_proposal.scss
@@ -128,9 +128,9 @@ span.glyphicon-question-sign {
 }
 
 div.col-md-4 {
-    h3 {
-      display: inline-block;
-    }
+  h3 {
+    display: inline-block;
+  }
 }
 
 .invite-btns {
@@ -141,6 +141,36 @@ div.col-md-4 {
   display: none;
   form {
     margin-top: 0px;
+  }
+}
+
+#edit-tags-icon {
+  color: $bright-blue;
+  font-size: $font-size-large;
+  margin-left: 5px;
+}
+
+.reviewer-tags-form-wrapper {
+  display: none;
+  padding-top: 5px;
+  text-align: left;
+  #autocomplete-options {
+    display: none;
+  }
+  .form-group {
+    display: inline-block;
+  }
+  .selectize-input.items .item {
+    background: $state-success-bg;
+    border: 1px solid darken($state-success-bg, 30%);
+    color: $state-success-text;
+    text-shadow: none;
+    .remove {
+      border-left: 1px solid darken($state-success-bg, 30%);
+    }
+  }
+  .selectize-dropdown-content > .option.active {
+    background: $state-success-bg;
   }
 }
 
@@ -162,21 +192,23 @@ div.col-md-4 {
   .proposal-meta {
     font-size: $font-size-base;
     color: $black;
-
     .proposal-meta-item {
       display: inline-block;
       margin-right: $padding-base-horizontal;
-
       strong {
         font-size: $font-size-xs;
         color: $gray;
       }
-
       .label {
         margin-bottom: 0;
       }
+      .info-item-heading {
+        text-decoration: underline;
+      }
     }
-
+    .review-tags-heading {
+      text-align: left;
+    }
     .proposal-description {
       line-height: 1;
       margin-bottom: $padding-base-vertical * 2;

--- a/app/assets/stylesheets/modules/_schedule.scss
+++ b/app/assets/stylesheets/modules/_schedule.scss
@@ -1,13 +1,6 @@
-
 #schedule {
-  @media only screen and (min-width: 950px) {
-    margin-top: 20px;
-  }
-  @media only screen and (max-width: 767px) {
-      margin-top: 110px;
-  }
+  margin-top: 20px;
 }
-
 
 .schedule-grid {
   $day-start: 8*60px;

--- a/app/assets/stylesheets/modules/_time-slot.scss
+++ b/app/assets/stylesheets/modules/_time-slot.scss
@@ -25,9 +25,7 @@
 }
 
 #rooms-partial {
-  @media only screen and (max-width: 767px) {
-    margin-top: 80px;
-  }
+  margin-top: 20px;
 }
 
 #organizer-time-slots {

--- a/app/controllers/staff/proposal_reviews_controller.rb
+++ b/app/controllers/staff/proposal_reviews_controller.rb
@@ -35,6 +35,8 @@ class Staff::ProposalReviewsController < Staff::ApplicationController
 
   def update
     authorize @proposal, :review?
+    tags = params[:proposal][:review_tags].downcase
+    params[:proposal][:review_tags] = Tagging.tags_string_to_array(tags)
 
     unless @proposal.update_without_touching_updated_by_speaker_at(proposal_review_tags_params)
       flash[:danger] = 'There was a problem saving the proposal.'
@@ -47,6 +49,6 @@ class Staff::ProposalReviewsController < Staff::ApplicationController
   private
 
   def proposal_review_tags_params
-    params.fetch(:proposal, {}).permit({review_tags: []})
+    params.fetch(:proposal, {}).permit(review_tags: [])
   end
 end

--- a/app/models/program_session.rb
+++ b/app/models/program_session.rb
@@ -124,7 +124,7 @@ end
 #  abstract          :text
 #  track_id          :integer
 #  session_format_id :integer
-#  state             :text             default("active")
+#  state             :text             default("draft")
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #  info              :text

--- a/app/views/shared/proposals/_tags_form.html.haml
+++ b/app/views/shared/proposals/_tags_form.html.haml
@@ -1,9 +1,12 @@
 = form_for proposal, url: event_staff_proposal_path(event, proposal), html: {role: 'form', remote: true} do |f|
-  .form-group.col-sm-10
+  .form-group.col-sm-8.col-md-offset-2
     .tag-list
       #autocomplete-options
         = (event.review_tags | proposal.review_tags)
       = f.text_field :review_tags, { value: proposal.review_tags.join(','), tabindex: '-1' }
 
-  .form-group.col-md-2
-    %button.btn.btn-success.pull-right{type: "submit"} Update
+  .form-group.col-sm-2
+    %button.btn.btn-success.btn-sm(type="submit")
+      %span.glyphicon.glyphicon-ok
+    #cancel-tags-editing.btn.btn-danger.btn-sm
+      %span.glyphicon.glyphicon-remove

--- a/app/views/shared/proposals/_tags_form.html.haml
+++ b/app/views/shared/proposals/_tags_form.html.haml
@@ -1,8 +1,9 @@
 = form_for proposal, url: event_staff_proposal_path(event, proposal), html: {role: 'form', remote: true} do |f|
-  .form-group
+  .form-group.col-sm-10
     .tag-list
-      = f.select :review_tags,
-        options_for_select(event.review_tags, proposal.review_tags),
-        {}, { class: 'multiselect review-tags', multiple: true }
-  .form-group
-    %button.btn.btn-success.pull-right{:type => "submit"} Update
+      #autocomplete-options
+        = (event.review_tags | proposal.review_tags)
+      = f.text_field :review_tags, { value: proposal.review_tags.join(','), tabindex: '-1' }
+
+  .form-group.col-md-2
+    %button.btn.btn-success.pull-right{type: "submit"} Update

--- a/app/views/staff/proposal_reviews/show.html.haml
+++ b/app/views/staff/proposal_reviews/show.html.haml
@@ -19,33 +19,17 @@
 .proposal-actions-bar
   .row
     .col-md-offset-8.col-md-4.text-right
-      = link_to(event_staff_proposals_path, class: "btn btn-primary btn-sm") do
-        &laquo; Return to Proposals
-      = link_to "Next Proposal", event_staff_proposal_path(uuid: "PLACEHOLDER"), class: "next-proposal btn btn-primary btn-sm", data: {"proposal-uuid" => proposal.uuid }
+      .btn-nav
+        = link_to(event_staff_proposals_path, class: "btn btn-primary btn-sm") do
+          &laquo; Return to Proposals
+        = link_to "Next Proposal", event_staff_proposal_path(uuid: "PLACEHOLDER"), class: "next-proposal btn btn-primary btn-sm", data: {"proposal-uuid" => proposal.uuid }
 
 #proposal
   .page-header.page-header-slim
     .row
-      .col-md-8
+      .col-md-6
         %h1
           = proposal.title
-    .row
-      .col-sm-6
-        .proposal-info-bar
-          .proposal-meta.proposal-description
-            .proposal-meta-item
-              %strong #{ 'Speaker'.pluralize(proposal.speakers.count) }:
-              %span Blind
-            .proposal-meta-item
-              %strong Format:
-              %span #{proposal.session_format_name}
-            .proposal-meta-item
-              %strong Track:
-              %span #{proposal.track_name}
-            -if proposal.tags.present?
-              .proposal-meta-item
-                %strong Tags:
-                %span #{proposal.tags_labels}
       .col-sm-6.text-right
         .proposal-info-bar
           .proposal-meta.proposal-description
@@ -55,11 +39,39 @@
             .proposal-meta-item
               %strong Updated:
               %span #{proposal.updated_in_words}
-            -if proposal.review_tags.present?
-              .proposal-meta-item
-                %strong Reviewer Tags:
-                %span.proposal-reviewer-tags #{proposal.review_tags_labels}
 
+    .row
+      .col-sm-6
+        .proposal-info-bar
+          .proposal-meta.proposal-description
+            .proposal-meta-item
+              .info-item-heading #{ 'Speaker'.pluralize(proposal.speakers.count) }
+              Blind
+            .proposal-meta-item
+              .info-item-heading Format
+              #{proposal.session_format_name}
+            .proposal-meta-item
+              .info-item-heading Track
+              #{proposal.track_name}
+            -if proposal.tags.present?
+              .proposal-meta-item
+                .info-item-heading Tags
+                #{proposal.tags_labels}
+      .col-sm-6.text-right
+        .proposal-info-bar
+          .proposal-meta.proposal-description
+            .proposal-meta-item
+              .info-item-heading.review-tags-heading
+                %div.inline Reviewer Tags
+                #edit-tags-icon.fa.fa-pencil-square-o
+              .proposal-reviewer-tags{ style: 'text-align:left;' }
+                -if proposal.review_tags.present?
+                  #{proposal.review_tags_labels}
+                -else
+                  %em None
+
+        .reviewer-tags-form-wrapper
+          = render 'shared/proposals/tags_form', locals: { event: event, proposal: proposal }
   .row
     .col-md-4
       = render partial: 'reviewer_contents', locals: { proposal: proposal }
@@ -75,16 +87,15 @@
 
     .col-md-4
       .widget.widget-card.widget-card-alt.flush-top
-        .widget-header
-          %h3 Review
+        - unless allow_rating?(proposal) || show_ratings?(rating) || proposal.internal_comments_style.nil?
+          .widget-header
+            %h3 Rating and Internal Comments
+          .widget-content
+            %p
+              %em N/A
+
         .widget-content
           = render partial: 'shared/proposals/rating_form', locals: { event: event, proposal: proposal, rating: rating }
-
-        - if event.reviewer_tags?
-          .widget-header
-            %h3 Reviewer Tags
-          .widget-content
-            = render partial: 'shared/proposals/tags_form', locals: { event: event, proposal: proposal }
 
         .internal-comments{ style: proposal.internal_comments_style }
           .widget-header

--- a/app/views/staff/proposal_reviews/show.html.haml
+++ b/app/views/staff/proposal_reviews/show.html.haml
@@ -61,16 +61,14 @@
         .proposal-info-bar
           .proposal-meta.proposal-description
             .proposal-meta-item
-              .info-item-heading.review-tags-heading
-                %div.inline Reviewer Tags
-                #edit-tags-icon.fa.fa-pencil-square-o
-              .proposal-reviewer-tags{ style: 'text-align:left;' }
+              .info-item-heading.review-tags-heading Reviewer Tags
+              .proposal-reviewer-tags{ style: 'float:left;' }
                 -if proposal.review_tags.present?
                   #{proposal.review_tags_labels}
                 -else
                   %em None
-
-        .reviewer-tags-form-wrapper
+              #edit-tags-icon.fa.fa-pencil
+        .review-tags-form-wrapper
           = render 'shared/proposals/tags_form', locals: { event: event, proposal: proposal }
   .row
     .col-md-4
@@ -80,7 +78,7 @@
       .widget.widget-card.flush-top
         .widget-header
           %i.fa.fa-comments
-          %h3= pluralize(proposal.public_comments.count, 'public comment')
+          %h3.comments-heading= pluralize(proposal.public_comments.count, 'Public Comment')
         .widget-content
           = render partial: 'proposals/comments',
             locals: { proposal: proposal, comments: proposal.public_comments }
@@ -89,10 +87,10 @@
       .widget.widget-card.widget-card-alt.flush-top
         - unless allow_rating?(proposal) || show_ratings?(rating) || proposal.internal_comments_style.nil?
           .widget-header
-            %h3 Rating and Internal Comments
+            %h3 Rating
           .widget-content
             %p
-              %em N/A
+              %em Ratings are closed
 
         .widget-content
           = render partial: 'shared/proposals/rating_form', locals: { event: event, proposal: proposal, rating: rating }
@@ -100,7 +98,7 @@
         .internal-comments{ style: proposal.internal_comments_style }
           .widget-header
             %i.fa.fa-comments
-            %h3= pluralize(proposal.internal_comments.count, 'internal comment')
+            %h3.comments-heading= pluralize(proposal.internal_comments.count, 'Internal Comment')
           .widget-content
             = render partial: 'proposals/comments',
                 locals: { proposal: proposal, comments: proposal.internal_comments }

--- a/app/views/staff/proposal_reviews/update.js.erb
+++ b/app/views/staff/proposal_reviews/update.js.erb
@@ -1,2 +1,3 @@
 document.getElementById('flash').innerHTML = '<%=j show_flash %>';
-$('.proposal-reviewer-tags').html('<%=j proposal.review_tags_labels %>');
+$('.proposal-reviewer-tags').html('<%=j proposal.review_tags_labels %>' || '<em>None</em>');
+$('.reviewer-tags-form-wrapper').hide();

--- a/app/views/staff/proposal_reviews/update.js.erb
+++ b/app/views/staff/proposal_reviews/update.js.erb
@@ -1,3 +1,4 @@
 document.getElementById('flash').innerHTML = '<%=j show_flash %>';
-$('.proposal-reviewer-tags').html('<%=j proposal.review_tags_labels %>' || '<em>None</em>');
-$('.reviewer-tags-form-wrapper').hide();
+$('.proposal-reviewer-tags').html('<%=j proposal.review_tags_labels %>' || '<em>None</em>').toggle();
+$('#edit-tags-icon').show();
+$('.review-tags-form-wrapper').hide();

--- a/app/views/staff/proposals/show.html.haml
+++ b/app/views/staff/proposals/show.html.haml
@@ -64,8 +64,8 @@
                     #{proposal.review_tags_labels}
                   -else
                     %em None
-                %i#edit-tags-icon.fa.fa-pencil-square-o
-        .reviewer-tags-form-wrapper
+                %i#edit-tags-icon.fa.fa-pencil
+        .review-tags-form-wrapper
           = render 'shared/proposals/tags_form', locals: { event: event, proposal: proposal }
 
 
@@ -88,7 +88,7 @@
       .widget.widget-card.flush-top
         .widget-header
           %i.fa.fa-comments
-          %h3= pluralize(proposal.public_comments.count, 'public comment')
+          %h3.comments-heading= pluralize(proposal.public_comments.count, 'Public Comment')
         .widget-content
           = render partial: 'proposals/comments', locals: { proposal: proposal, comments: proposal.public_comments }
 
@@ -108,6 +108,6 @@
         .internal-comments
           .widget-header
             %i.fa.fa-comments
-            %h3= pluralize(proposal.internal_comments.count, 'internal comment')
+            %h3.comments-heading= pluralize(proposal.internal_comments.count, 'Internal Comment')
           .widget-content
             = render partial: 'proposals/comments', locals: { proposal: proposal, comments: proposal.internal_comments }

--- a/app/views/staff/proposals/show.html.haml
+++ b/app/views/staff/proposals/show.html.haml
@@ -57,10 +57,17 @@
               %strong Track:
               %span
                 = render 'inline_track_edit', proposal: proposal
-            -if proposal.review_tags.present?
               .proposal-meta-item
                 %strong Reviewer Tags:
-                %span.proposal-reviewer-tags #{proposal.review_tags_labels}
+                %span.proposal-reviewer-tags
+                  -if proposal.review_tags.present?
+                    #{proposal.review_tags_labels}
+                  -else
+                    %em None
+                %i#edit-tags-icon.fa.fa-pencil-square-o
+        .reviewer-tags-form-wrapper
+          = render 'shared/proposals/tags_form', locals: { event: event, proposal: proposal }
+
 
   .row
     .col-md-4
@@ -97,12 +104,6 @@
           %h3 Review
         .widget-content
           = render partial: 'shared/proposals/rating_form', locals: { event: event, proposal: proposal, rating: @rating }
-
-        - if event.reviewer_tags?
-          .widget-header
-            %h3 Reviewer Tags
-          .widget-content
-            = render partial: 'shared/proposals/tags_form', locals: { event: event, proposal: proposal }
 
         .internal-comments
           .widget-header

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -86,9 +86,9 @@ ActiveRecord::Schema.define(version: 20160927205019) do
     t.text     "abstract"
     t.integer  "track_id"
     t.integer  "session_format_id"
-    t.text     "state",             default: "active"
-    t.datetime "created_at",                           null: false
-    t.datetime "updated_at",                           null: false
+    t.text     "state",             default: "draft"
+    t.datetime "created_at",                          null: false
+    t.datetime "updated_at",                          null: false
     t.text     "info"
   end
 


### PR DESCRIPTION
- Reworked proposal-info-bar from inline to stacked 
- Moved reviewer tags form to pencil icon in proposal-info-bar; selectized it
- Handled case where neither Rating or Internal comments are shown in the 'Review' widget
- On-demand body padding for pages where fixed subnavs are present
- Fixed nav buttons spacing
- Modified the proposal review page that is accessible through 'Program', as there were a few CSS ripple effects