### PR TITLE
#223 Fill-in Nav Holes

### DIFF
--- a/app/controllers/concerns/activate_navigation.rb
+++ b/app/controllers/concerns/activate_navigation.rb
@@ -5,94 +5,105 @@ module ActivateNavigation
 
   included do
     helper_method :nav_item_class
-    helper_method :program_subnav_item_class
-    helper_method :event_subnav_item_class
-    helper_method :schedule_subnav_item_class
+    helper_method :subnav_item_class
   end
 
   def nav_item_class(key)
-    return 'active' if matches_nav_path?(key, nav_item_map)
+    initialize_nav
+    return 'active' if @active_nav_key == key
   end
 
-  def event_subnav_item_class(key)
-    return 'active' if matches_nav_path?(key, event_subnav_item_map)
-  end
-
-  def program_subnav_item_class(key)
-    return 'active' if matches_nav_path?(key, program_subnav_item_map)
-  end
-
-  def schedule_subnav_item_class(key)
-    return 'active' if matches_nav_path?(key, schedule_subnav_item_map)
+  def subnav_item_class(key)
+    initialize_nav
+    return 'active' if @active_subnav_key == key
   end
 
   private
 
-  def matches_nav_path?(key, paths={})
-    if paths.is_a?(String)
-      return paths==request.path
+  def initialize_nav
+    return if @active_nav_key || @active_subnav_key
 
-    elsif paths.is_a?(Hash)
-      return matches_nav_path?(nil, paths.values) if key.nil?
-      return paths.any?{|k, p| k==key && matches_nav_path?(nil, p) } # only recurse if the key matches
+    @active_nav_key, subnav_map = find_first(nav_item_map)
+    @active_subnav_key, nop = find_first(subnav_map)
+  end
+
+  def find_first(item_map)
+    return unless item_map.is_a?(Hash)
+
+    item_map.find do |key, paths|
+      match?(paths)
+    end
+  end
+
+  def match?(paths)
+    if paths.is_a?(String)
+      paths == request.path
+
+    elsif paths.is_a?(Regexp)
+      paths =~ request.path
 
     elsif paths.is_a?(Array)
-      return paths.any?{|p| !p.nil? && matches_nav_path?(nil, p) }
+      paths.any?{|p| match?(p) }
+
+    elsif paths.is_a?(Hash)
+      find_first(paths).present?
     end
   end
 
   def nav_item_map
     @nav_item_map ||= {
         'my-proposals-link' => [
-            add_path(:proposals),
-            add_path(:event_proposal, current_event, @proposal.try(:uuid?) ? @proposal : nil)
+            starts_with_path(:proposals),
+            starts_with_path(:event_event_proposals, current_event)
         ],
-        'event-review-proposals-link' => [
-            add_path(:event_staff_proposals, current_event),
-            add_path(:event_staff_proposal, current_event, @proposal.try(:uuid?) ? @proposal : nil)
-        ],
-        'event-program-link' => program_subnav_item_map.values,
-        'event-schedule-link' => add_path(:event_staff_schedule_grid, current_event),
-        'event-dashboard-link' => event_subnav_item_map.values,
+        'event-review-proposals-link' => starts_with_path(:event_staff_proposals, current_event),
+        'event-program-link' => program_subnav_item_map,
+        'event-schedule-link' => schedule_subnav_item_map,
+        'event-dashboard-link' => event_subnav_item_map,
     }
   end
 
   def event_subnav_item_map
     @event_subnav_item_map ||= {
-        'event-staff-dashboard-link' => add_path(:event_staff, current_event),
-        'event-staff-info-link' => add_path(:event_staff_info, current_event),
-        'event-staff-teammates-link' => add_path(:event_staff_teammates, current_event),
-        'event-staff-config-link' => add_path(:event_staff_config, current_event),
-        'event-staff-guidelines-link' => add_path(:event_staff_guidelines, current_event),
-        'event-staff-speaker-emails-link' => add_path(:event_staff_speaker_email_notifications, current_event),
+        'event-staff-dashboard-link' => exact_path(:event_staff, current_event),
+        'event-staff-info-link' => [
+            exact_path(:event_staff_info, current_event),
+            exact_path(:event_staff_edit, current_event)
+        ],
+        'event-staff-teammates-link' => exact_path(:event_staff_teammates, current_event),
+        'event-staff-config-link' => exact_path(:event_staff_config, current_event),
+        'event-staff-guidelines-link' => exact_path(:event_staff_guidelines, current_event),
+        'event-staff-speaker-emails-link' => exact_path(:event_staff_speaker_email_notifications, current_event),
     }
   end
 
   def program_subnav_item_map
     @program_subnav_item_map ||= {
         'event-program-proposals-selection-link' => [
-            add_path(:selection_event_staff_program_proposals, current_event),
-            # add_path(:event_staff_program_proposal, current_event, @proposal)
-            #How to leverage session[:prev_page] here? Considering lamdas
+            starts_with_path(:selection_event_staff_program_proposals, current_event),
+        # add_path(:event_staff_program_proposal, current_event, @proposal)
+        #How to leverage session[:prev_page] here? Considering lamdas
         ],
-        'event-program-proposals-link' => [
-            add_path(:event_staff_program_proposals, current_event),
-            add_path(:event_staff_program_proposal, current_event, @proposal.try(:uuid?) ? @proposal : nil)
-        ],
-        'event-program-sessions-link' => add_path(:event_staff_program_sessions, current_event),
-        'event-program-speakers-link' => add_path(:event_staff_program_speakers, current_event),
+        'event-program-proposals-link' => starts_with_path(:event_staff_program_proposals, current_event),
+        'event-program-sessions-link' => starts_with_path(:event_staff_program_sessions, current_event),
+        'event-program-speakers-link' => starts_with_path(:event_staff_program_speakers, current_event)
     }
   end
 
   def schedule_subnav_item_map
     @schedule_subnav_item_map ||= {
-      'event-schedule-time-slots-link' => add_path(:event_staff_schedule_time_slots, current_event),
-      'event-schedule-rooms-link' => add_path(:event_staff_schedule_rooms, current_event),
-      'event-schedule-grid-link' => add_path(:event_staff_schedule_grid, current_event)
+      'event-schedule-time-slots-link' => exact_path(:event_staff_schedule_time_slots, current_event),
+      'event-schedule-rooms-link' => exact_path(:event_staff_schedule_rooms, current_event),
+      'event-schedule-grid-link' => exact_path(:event_staff_schedule_grid, current_event)
     }
   end
 
-  def add_path(sym, *deps)
+  def exact_path(sym, *deps)
     send(sym.to_s + '_path', *deps) unless deps.include?(nil) # don't generate the path unless all dependencies are present
+  end
+
+  def starts_with_path(sym, *deps)
+    starts_with = exact_path(sym, *deps)
+    Regexp.new(Regexp.escape(starts_with) + ".*") if starts_with
   end
 end

--- a/app/views/layouts/nav/staff/_event_subnav.html.haml
+++ b/app/views/layouts/nav/staff/_event_subnav.html.haml
@@ -2,27 +2,27 @@
   .subnavbar-inner
     .container-fluid
       %ul.mainnav
-        %li{class: event_subnav_item_class("event-staff-dashboard-link")}
+        %li{class: subnav_item_class("event-staff-dashboard-link")}
           = link_to event_staff_path do
             %i.fa.fa-dashboard
             %span Dashboard
-        %li{class: event_subnav_item_class("event-staff-info-link")}
+        %li{class: subnav_item_class("event-staff-info-link")}
           = link_to event_staff_info_path do
             %i.fa.fa-info-circle
             %span Info
-        %li{class: event_subnav_item_class("event-staff-teammates-link")}
+        %li{class: subnav_item_class("event-staff-teammates-link")}
           = link_to event_staff_teammates_path do
             %i.fa.fa-users
             %span Team
-        %li{class: event_subnav_item_class("event-staff-config-link")}
+        %li{class: subnav_item_class("event-staff-config-link")}
           = link_to event_staff_config_path do
             %i.fa.fa-wrench
             %span Config
-        %li{class: event_subnav_item_class("event-staff-guidelines-link")}
+        %li{class: subnav_item_class("event-staff-guidelines-link")}
           = link_to event_staff_guidelines_path do
             %i.fa.fa-list
             %span Guidelines
-        %li{class: event_subnav_item_class("event-staff-speaker-emails-link")}
+        %li{class: subnav_item_class("event-staff-speaker-emails-link")}
           = link_to event_staff_speaker_email_notifications_path do
             %i.fa.fa-envelope-o
             %span Speaker Emails

--- a/app/views/layouts/nav/staff/_program_subnav.html.haml
+++ b/app/views/layouts/nav/staff/_program_subnav.html.haml
@@ -1,19 +1,19 @@
 .navbar.navbar-fixed-top.program-subnav
   .container-fluid
     %ul.nav.navbar-nav.navbar-right
-      %li{class: program_subnav_item_class("event-program-proposals-link")}
+      %li{class: subnav_item_class("event-program-proposals-link")}
         = link_to event_staff_program_proposals_path do
           %i.fa.fa-balance-scale
           %span Proposals
-      %li{class: program_subnav_item_class("event-program-proposals-selection-link")}
+      %li{class: subnav_item_class("event-program-proposals-selection-link")}
         = link_to selection_event_staff_program_proposals_path do
           %i.fa.fa-gavel
           %span Selection
-      %li{class: program_subnav_item_class("event-program-sessions-link")}
+      %li{class: subnav_item_class("event-program-sessions-link")}
         = link_to event_staff_program_sessions_path do
           %i.fa.fa-check
           %span Sessions
-      %li{class: program_subnav_item_class("event-program-speakers-link")}
+      %li{class: subnav_item_class("event-program-speakers-link")}
         = link_to event_staff_program_speakers_path do
           %i.fa.fa-users
           %span Speakers

--- a/app/views/layouts/nav/staff/_schedule_subnav.html.haml
+++ b/app/views/layouts/nav/staff/_schedule_subnav.html.haml
@@ -1,15 +1,15 @@
 .navbar.navbar-fixed-top.schedule-subnav
   .container-fluid
     %ul.nav.navbar-nav.navbar-right
-      %li{class: schedule_subnav_item_class('event-schedule-grid-link')}
+      %li{class: subnav_item_class('event-schedule-grid-link')}
         = link_to event_staff_schedule_grid_path do
           %i.fa.fa-calendar-times-o
           %span Grid
-      %li{class: schedule_subnav_item_class('event-schedule-time-slots-link')}
+      %li{class: subnav_item_class('event-schedule-time-slots-link')}
         = link_to event_staff_schedule_time_slots_path do
           %i.fa.fa-clock-o
           %span Time Slots
-      %li{class: schedule_subnav_item_class('event-schedule-rooms-link')}
+      %li{class: subnav_item_class('event-schedule-rooms-link')}
         = link_to event_staff_schedule_rooms_path do
           %i.fa.fa-tag
           %span Rooms


### PR DESCRIPTION
- Nav and subnav items correctly highlight on all Session and Speaker pages.

- Refactored the nav module for clarity & flexibility. Now supports Regexp matching.

- Only first match is used, which fixes dupe highlight bug that was happening in some cases.