### PR TITLE
Use asset-url for login icons

### DIFF
--- a/app/assets/stylesheets/modules/_icons.scss
+++ b/app/assets/stylesheets/modules/_icons.scss
@@ -18,11 +18,11 @@
 }
 
 .icon-twitter {
-  background-image: url(twitter_32.png);
+  background-image: asset-url("twitter_32.png");
   @include icon-generic;
 }
 
 .icon-github {
-  background-image: url(github_32.png);
+  background-image: asset-url("github_32.png");
   @include icon-generic;
 }


### PR DESCRIPTION
There may be a reason that these didn’t use the asset-pipeline-y form but I couldn’t see anything obvious and this change does indeed make the icons work on Heroku.