### PR TITLE
Organizer cannot update status for incomplete event (#267)

### DIFF
--- a/app/controllers/staff/events_controller.rb
+++ b/app/controllers/staff/events_controller.rb
@@ -58,6 +58,10 @@ class Staff::EventsController < Staff::ApplicationController
       redirect_to event_staff_info_path(@event), notice: "Event status was successfully updated."
     else
       flash[:danger] = "There was a problem updating the event status. Please try again."
+      flash[:danger] += @event.errors.messages.values.flatten.map do |m|
+        " <br>#{m}"
+      end.join if @event.errors.present?
+      @event.reload
       render :info
     end
   end
@@ -112,10 +116,10 @@ class Staff::EventsController < Staff::ApplicationController
 
   def open_cfp
     authorize_update
-    if @event.open_cfp
+    if @event.update_attributes(state: Event::STATUSES[:open])
       flash[:info] = "Your CFP was successfully opened."
     else
-      flash[:danger] = "There was a problem opening your CFP: #{@event.errors.full_messages.to_sentence}"
+      flash['danger alert-confirm'] = "There was a problem opening your CFP: #{@event.errors.full_messages.to_sentence}"
     end
     redirect_to event_staff_path(@event)
   end

--- a/app/views/staff/events/info.html.haml
+++ b/app/views/staff/events/info.html.haml
@@ -9,7 +9,8 @@
           - if current_user.organizer_for_event?(event)
             .btn-nav
               = link_to "Edit Info", event_staff_edit_path(event), class: "btn btn-primary"
-              = link_to "Change Status", '#', class: "btn btn-primary status-button"
+              - if event.checklist_complete?
+                = link_to "Change Status", '#', class: "btn btn-primary status-button"
             .status-dropdown.pull-right
               = form_for(event, url: event_staff_update_status_path(event)) do |f|
                 = f.select(:state, options_for_select(Event::STATUSES.values, f.object.state))

--- a/app/views/staff/events/show.html.haml
+++ b/app/views/staff/events/show.html.haml
@@ -102,7 +102,7 @@
             %h3 CFP
           .widget-content
             %strong.text-primary No CFP Statistics
-            - if event.incomplete_checklist_items.empty?
+            - if event.checklist_complete?
               - if current_user.organizer_for_event?(current_event)
                 = link_to "Open CFP", event_staff_open_cfp_path(current_event), method: :patch,
                   class: "btn btn-success btn-lg cfp-button",

--- a/spec/factories/teammates.rb
+++ b/spec/factories/teammates.rb
@@ -3,7 +3,7 @@ FactoryGirl.define do
     event { Event.first || FactoryGirl.create(:event) }
 
     sequence :email do |n|
-      "email#{n}@factory.com"
+      "teammate_email#{n}@factory.com"
     end
 
     trait :has_been_invited do

--- a/spec/features/staff/event_spec.rb
+++ b/spec/features/staff/event_spec.rb
@@ -35,7 +35,7 @@ feature "Event Dashboard" do
       visit event_staff_info_path(organizer_teammate.event)
       expect(page).to have_content organizer_teammate.event.name
       expect(page).to have_link "Edit Info"
-      expect(page).to have_link "Change Status"
+      expect(page).not_to have_link "Change Status"
 
       click_on "Edit Info"
 
@@ -45,8 +45,12 @@ feature "Event Dashboard" do
       expect(current_path).to eq(event_staff_info_path(organizer_teammate.event))
     end
 
-    it "can change event status" do
-      visit event_staff_info_path(organizer_teammate.event)
+    it "can change event status if checklist complete" do
+      event = organizer_teammate.event
+      visit event_staff_info_path(event)
+      expect(page).not_to have_link "Change Status"
+      create(:program_session, event: event)
+      visit event_staff_info_path(event)
 
       within('.page-header') do
         expect(page).to have_content("Event Status: Draft")


### PR DESCRIPTION
- Hide 'Update Status' button if event cannot be opened
- Consolidate validation logic for opening an event

