### PR TITLE
Add additional patchTimeSlot call when needed

### DIFF
--- a/app/javascript/apiCalls.js
+++ b/app/javascript/apiCalls.js
@@ -1,12 +1,12 @@
 export function patchTimeSlot(slot, talk, csrfToken) {
-  const talkID = talk.slot ? '' : talk.id.toString();
+  const talkID = talk === null ? '' : talk.id.toString();
 
   const data = JSON.stringify({
     time_slot: {
       program_session_id: talkID
     }
   });
-  debugger
+  
   if (slot.update_path) {
     return fetch(slot.update_path, {
       method: "PATCH",

--- a/app/javascript/components/Schedule/ScheduleSlot.js
+++ b/app/javascript/components/Schedule/ScheduleSlot.js
@@ -16,6 +16,9 @@ class ScheduleSlot extends React.Component {
     
     patchTimeSlot(slot, session, csrf)
       .then(() => {
+        if (session.slot) {
+          patchTimeSlot(session.slot, null, csrf)
+        }
         this.props.scheduleSession(session, slot);
         this.props.changeDragged(null);
       })


### PR DESCRIPTION
When dragging from another slot it was not working correctly, this addresses that by calling a patch on the previous slot, and on the new target slot.