### PR TITLE
Adds display error for scheduler

### DIFF
--- a/app/assets/stylesheets/modules/_schedule.scss
+++ b/app/assets/stylesheets/modules/_schedule.scss
@@ -538,6 +538,12 @@ input[type=number]::-webkit-outer-spin-button {
       margin: auto;
     }
 
+    .scheduling-error.alert.alert-danger {
+      position: fixed;
+      margin: 60px auto 0;
+      top: 0;
+    }
+
     .schedule_slot {
       background: #fff;
       border: .5px solid rgba(204, 204, 204, 0.5);

--- a/app/javascript/apiCalls.js
+++ b/app/javascript/apiCalls.js
@@ -3,7 +3,7 @@ export function patchTimeSlot(slot, talk, csrfToken) {
 
   const data = JSON.stringify({
     time_slot: {
-      program_session_id: talkID
+      program_session_id: talkID,
     }
   });
   

--- a/app/javascript/components/Schedule.js
+++ b/app/javascript/components/Schedule.js
@@ -173,7 +173,7 @@ class Schedule extends Component {
       previewSlots,
       slots,
       rooms,
-      sessionFormats
+      sessionFormats,
     } = this.state
 
     const headers = rooms.map(room => (

--- a/app/javascript/components/Schedule/Alert.js
+++ b/app/javascript/components/Schedule/Alert.js
@@ -1,0 +1,21 @@
+import React, { Component, Fragment } from "react"
+import PropTypes from "prop-types"
+
+class Alert extends Component {
+  render() {
+    const message = this.props.message;
+
+    return (
+      <div className="scheduling-error alert alert-danger">
+        <button className='close' data-dismiss='alert'> &times; </button>
+        { message }
+      </div>
+    )
+  }
+}
+
+Alert.propTypes = {
+  message: PropTypes.string
+}
+
+export default Alert

--- a/app/javascript/components/Schedule/DayView.js
+++ b/app/javascript/components/Schedule/DayView.js
@@ -18,7 +18,7 @@ class DayView extends Component {
       previewSlots,
       rooms,
       slots,
-      handleMoveSessionResponse
+      handleMoveSessionResponse,
     } = this.props
 
     let rows = rooms.map(room => {

--- a/app/javascript/components/Schedule/FlashMessages.js
+++ b/app/javascript/components/Schedule/FlashMessages.js
@@ -1,0 +1,27 @@
+import React, { Component } from "react"
+import PropTypes from "prop-types"
+import Alert from './Alert'
+
+class FlashMessages extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      messages: props.messages
+    }
+  }
+
+  render() {
+    return(
+      <div>
+        { this.state.messages.map( message =>
+          <Alert key={ message } message={ message } />) }
+      </div>
+    );
+  }
+}
+
+FlashMessages.propTypes = {
+  messages: PropTypes.array
+}
+
+export default FlashMessages

--- a/app/javascript/components/Schedule/ScheduleColumn.js
+++ b/app/javascript/components/Schedule/ScheduleColumn.js
@@ -19,7 +19,7 @@ class ScheduleColumn extends Component {
       tracks,
       previewSlots,
       slots,
-      handleMoveSessionResponse
+      handleMoveSessionResponse,
     } = this.props
 
     const roomID = room.id


### PR DESCRIPTION
WIP
Displays error for `patchTimeSlot` calls (`TimeSlotsController#update`)

### Testing Notes:
To force error on drag/drop, replace the `update` action in `staff/grids/time_slots_controller` with the below:
```
  def update
    @time_slot.errors.add(:conference_day, "is unavailable")
    @time_slot.errors.add(:start_time, "is too early in the morning")

    respond_to do |format|
      format.json { render json: update_response.merge({ errors: @time_slot.errors.full_messages, status: :bad_request }) }
    end
  rescue StandardError => e
    render json: update_response.merge({errors: ["There was a problem updating this time slot."], status: 500})
  end
```