### PR TITLE
289 time slot modal

### DIFF
--- a/app/assets/stylesheets/modules/_schedule.scss
+++ b/app/assets/stylesheets/modules/_schedule.scss
@@ -655,7 +655,7 @@ input[type=number]::-webkit-outer-spin-button {
   }
 }
 
-.bulk-modal-container {
+.modal-container {
   position: fixed;
   top: 0;
   left: 0;
@@ -668,6 +668,7 @@ input[type=number]::-webkit-outer-spin-button {
     width: 600px;
     max-width: 100%;
     max-height: 100%;
+    min-height: 200px;
     background-color: #fff;
     border: 1px solid #6d6b6b;
     margin: 100px auto;

--- a/app/assets/stylesheets/modules/_schedule.scss
+++ b/app/assets/stylesheets/modules/_schedule.scss
@@ -690,7 +690,7 @@ input[type=number]::-webkit-outer-spin-button {
 
         select {
           display: block;
-          width: 50px;
+          width: unset;
           height: 30px;
           margin: 10px 0px;;
         }

--- a/app/assets/stylesheets/modules/_schedule.scss
+++ b/app/assets/stylesheets/modules/_schedule.scss
@@ -717,6 +717,11 @@ input[type=number]::-webkit-outer-spin-button {
           border: 1px solid #A6A6A6;
           padding: 5px;
         }
+
+        .bulk-checkbox {
+          display: inline-block;
+          width: unset;
+        }
       }
 
       .start-times {

--- a/app/assets/stylesheets/modules/_schedule.scss
+++ b/app/assets/stylesheets/modules/_schedule.scss
@@ -635,7 +635,7 @@ input[type=number]::-webkit-outer-spin-button {
   }
 }
 
-.program_session_card {
+.program_session_card, .slot_info_card {
   width: 95%;
   margin: 1em auto;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
@@ -655,6 +655,10 @@ input[type=number]::-webkit-outer-spin-button {
     align-items: center;
     justify-content: center;
   }
+}
+
+.slot_info_card {
+  cursor: default;
 }
 
 .modal-container {
@@ -683,8 +687,12 @@ input[type=number]::-webkit-outer-spin-button {
       display: inherit;
       
       label {
-        width: 90%;
+        width: 100%;
         margin: 10px auto 0px;
+
+        p {
+          font-weight: normal;
+        }
 
         .required {
           color: #751317
@@ -692,9 +700,16 @@ input[type=number]::-webkit-outer-spin-button {
 
         select {
           display: block;
-          width: unset;
+          width: 100%;
           height: 30px;
-          margin: 10px 0px;;
+          margin: 0px;
+        }
+
+        input, textarea {
+          width: 100%;
+          display: block;
+          border: 1px solid #A6A6A6;
+          padding: 5px;
         }
       }
 

--- a/app/assets/stylesheets/modules/_schedule.scss
+++ b/app/assets/stylesheets/modules/_schedule.scss
@@ -556,6 +556,7 @@ input[type=number]::-webkit-outer-spin-button {
         .card_header {
           padding: .3em;
           max-height: 35%;
+          min-height: 22px;
           overflow: hidden;
         }
 

--- a/app/assets/stylesheets/modules/_schedule.scss
+++ b/app/assets/stylesheets/modules/_schedule.scss
@@ -546,12 +546,14 @@ input[type=number]::-webkit-outer-spin-button {
       margin: auto;
       overflow: hidden;
 
-      .program_session_card {
+      .program_session_card, .slot_info_card {
         height: 95%;
+        width: 95%;
         box-shadow: none;
         margin: 2px auto;
         box-sizing: border-box;
         font-size: .8em;
+        text-align: center;
 
         .card_header {
           padding: .3em;

--- a/app/assets/stylesheets/modules/_schedule.scss
+++ b/app/assets/stylesheets/modules/_schedule.scss
@@ -587,6 +587,7 @@ input[type=number]::-webkit-outer-spin-button {
     display: inline-block;
     box-sizing: border-box;
     width: 285px;
+    min-width: 285px;
     padding: 0px 20px;
     top: 150px;
     right: -2px;
@@ -665,6 +666,7 @@ input[type=number]::-webkit-outer-spin-button {
 
 .slot_info_card {
   cursor: default;
+  background: transparent;
 }
 
 .modal-container {

--- a/app/controllers/staff/grids/time_slots_controller.rb
+++ b/app/controllers/staff/grids/time_slots_controller.rb
@@ -1,6 +1,6 @@
 class Staff::Grids::TimeSlotsController < Staff::ApplicationController
   include ScheduleSupport
-
+  protect_from_forgery except: :edit
   before_action :set_time_slot, only: [:edit, :update]
 
   helper_method :time_slot_decorated

--- a/app/javascript/apiCalls.js
+++ b/app/javascript/apiCalls.js
@@ -1,9 +1,13 @@
 export function patchTimeSlot(slot, talk, csrfToken) {
   const talkID = talk === null ? '' : talk.id.toString();
-
+  
   const data = JSON.stringify({
     time_slot: {
-      program_session_id: talkID
+      program_session_id: talkID,
+      title: slot.title || '',
+      track_id: slot.track_id || '',
+      presenter: slot.presenter || '',
+      description: slot.description || ''
     }
   });
   

--- a/app/javascript/components/Schedule.js
+++ b/app/javascript/components/Schedule.js
@@ -232,6 +232,7 @@ class Schedule extends Component {
             rooms={rooms}
             slots={slots}
             handleMoveSessionResponse={this.handleMoveSessionResponse}
+            unscheduledSessions={unscheduledSessions}
           />
           <UnscheduledArea
             unscheduledSessions={unscheduledSessions}

--- a/app/javascript/components/Schedule.js
+++ b/app/javascript/components/Schedule.js
@@ -233,6 +233,7 @@ class Schedule extends Component {
             slots={slots}
             handleMoveSessionResponse={this.handleMoveSessionResponse}
             unscheduledSessions={unscheduledSessions}
+            sessionFormats={sessionFormats}
           />
           <UnscheduledArea
             unscheduledSessions={unscheduledSessions}

--- a/app/javascript/components/Schedule/BulkCreateModal.js
+++ b/app/javascript/components/Schedule/BulkCreateModal.js
@@ -90,6 +90,7 @@ class BulkCreateModal extends Component {
             name={room.id.toString()}
             checked={checked}
             onChange={this.changeRooms}
+            className='bulk-checkbox'
           />
           <span>{room.name}</span>
         </div>

--- a/app/javascript/components/Schedule/BulkCreateModal.js
+++ b/app/javascript/components/Schedule/BulkCreateModal.js
@@ -122,7 +122,7 @@ class BulkCreateModal extends Component {
     }
 
     return (
-      <div className='bulk-modal-container'>
+      <div className='modal-container'>
         <div className='bulk-modal'>
           <div className='modal-header' >
             <h3>Bulk Generate Time Slots</h3>

--- a/app/javascript/components/Schedule/DayView.js
+++ b/app/javascript/components/Schedule/DayView.js
@@ -18,7 +18,8 @@ class DayView extends Component {
       previewSlots,
       rooms,
       slots,
-      handleMoveSessionResponse
+      handleMoveSessionResponse,
+      unscheduledSessions
     } = this.props
 
     let rows = rooms.map(room => {
@@ -40,6 +41,7 @@ class DayView extends Component {
           previewSlots={previewSlots}
           slots={slots}
           handleMoveSessionResponse={handleMoveSessionResponse}
+          unscheduledSessions={unscheduledSessions}
         />
       )
     })
@@ -63,7 +65,8 @@ DayView.propTypes = {
   sessions: PropTypes.array,
   tracks: PropTypes.array,
   previewSlots: PropTypes.array,
-  handleMoveSessionResponse: PropTypes.func
+  handleMoveSessionResponse: PropTypes.func,
+  unscheduledSessions: PropTypes.array
 }
 DayView.defaultProps = {sessions: []}
 

--- a/app/javascript/components/Schedule/DayView.js
+++ b/app/javascript/components/Schedule/DayView.js
@@ -19,7 +19,8 @@ class DayView extends Component {
       rooms,
       slots,
       handleMoveSessionResponse,
-      unscheduledSessions
+      unscheduledSessions,
+      sessionFormats
     } = this.props
 
     let rows = rooms.map(room => {
@@ -42,6 +43,7 @@ class DayView extends Component {
           slots={slots}
           handleMoveSessionResponse={handleMoveSessionResponse}
           unscheduledSessions={unscheduledSessions}
+          sessionFormats={sessionFormats}
         />
       )
     })
@@ -66,7 +68,8 @@ DayView.propTypes = {
   tracks: PropTypes.array,
   previewSlots: PropTypes.array,
   handleMoveSessionResponse: PropTypes.func,
-  unscheduledSessions: PropTypes.array
+  unscheduledSessions: PropTypes.array,
+  sessionFormats: PropTypes.array
 }
 DayView.defaultProps = {sessions: []}
 

--- a/app/javascript/components/Schedule/ProgramSession.js
+++ b/app/javascript/components/Schedule/ProgramSession.js
@@ -6,8 +6,9 @@ class ProgramSession extends Component {
     super(props)
   }
 
-  drag = (session) => {
+  drag = (session, e) => {
     this.props.onDrag(session)
+    e.dataTransfer.setData('text', 'anything');  
   }
 
   dragEnd = e => {
@@ -23,7 +24,7 @@ class ProgramSession extends Component {
     const trackName = sessionTrack ? sessionTrack.name : ''
 
     return(
-      <div className='program_session_card' draggable={true} onDragStart={() => this.drag(session)} onDragEnd={(e) => this.dragEnd(e)}>
+      <div className='program_session_card' draggable={true} onDragStart={(e) => this.drag(session, e)} onDragEnd={(e) => this.dragEnd(e)}>
         <div className='card_header' style={{'backgroundColor': bkgColor}}>{trackName}</div>
         <div className='card_body'>
           <p>{session.title}</p>

--- a/app/javascript/components/Schedule/ScheduleColumn.js
+++ b/app/javascript/components/Schedule/ScheduleColumn.js
@@ -20,7 +20,8 @@ class ScheduleColumn extends Component {
       previewSlots,
       slots,
       handleMoveSessionResponse,
-      unscheduledSessions
+      unscheduledSessions,
+      sessionFormats
     } = this.props
 
     const roomID = room.id
@@ -49,6 +50,7 @@ class ScheduleColumn extends Component {
             tracks={tracks}
             handleMoveSessionResponse={handleMoveSessionResponse}
             unscheduledSessions={unscheduledSessions}
+            sessionFormats={sessionFormats}
           />
         )
       })

--- a/app/javascript/components/Schedule/ScheduleColumn.js
+++ b/app/javascript/components/Schedule/ScheduleColumn.js
@@ -19,7 +19,8 @@ class ScheduleColumn extends Component {
       tracks,
       previewSlots,
       slots,
-      handleMoveSessionResponse
+      handleMoveSessionResponse,
+      unscheduledSessions
     } = this.props
 
     const roomID = room.id
@@ -47,6 +48,7 @@ class ScheduleColumn extends Component {
             sessions={sessions}
             tracks={tracks}
             handleMoveSessionResponse={handleMoveSessionResponse}
+            unscheduledSessions={unscheduledSessions}
           />
         )
       })
@@ -81,7 +83,8 @@ ScheduleColumn.propTypes = {
   sessions: PropTypes.array,
   tracks: PropTypes.array,
   previewSlots: PropTypes.array,
-  handleMoveSessionResponse: PropTypes.func
+  handleMoveSessionResponse: PropTypes.func,
+  unscheduledSessions: PropTypes.array
 }
 
 ScheduleColumn.defaultProps = {sessions: []}

--- a/app/javascript/components/Schedule/ScheduleSlot.js
+++ b/app/javascript/components/Schedule/ScheduleSlot.js
@@ -10,7 +10,7 @@ class ScheduleSlot extends Component {
     super(props)
     this.state = {
       hoverDrag: false,
-      modalShown: false
+      modalShowing: false
     }
   }
   
@@ -56,11 +56,17 @@ class ScheduleSlot extends Component {
   }
 
   showModal = () => {
-    this.setState({modalShown: true})
+    if (!this.state.modalShowing) {
+      this.setState({modalShowing: true})
+    }
+  }
+
+  closeModal = () => {
+    this.setState({modalShowing: false})
   }
 
   render() {
-    const { slot, ripTime, startTime, sessions, tracks, csrf, unscheduledSessions } = this.props
+    const { slot, ripTime, startTime, sessions, tracks, csrf, unscheduledSessions, handleMoveSessionResponse } = this.props
     
     const slotStartTime = ripTime(slot.start_time)
     const slotEndTime = ripTime(slot.end_time)
@@ -93,7 +99,16 @@ class ScheduleSlot extends Component {
         onClick={this.showModal}
       >
         {session}
-        {this.state.modalShown && <TimeSlotModal csrf={csrf} slot={this.props.slot} matchedSession={matchedSession} unscheduledSessions={unscheduledSessions} tracks={tracks}/>}
+        {this.state.modalShowing === true && <TimeSlotModal 
+          csrf={csrf} 
+          slot={this.props.slot} 
+          matchedSession={matchedSession} 
+          unscheduledSessions={unscheduledSessions} 
+          tracks={tracks} 
+          closeModal={this.closeModal}
+          sessions={sessions}
+          handleMoveSessionResponse={handleMoveSessionResponse}
+        />}
       </div>
     )
   }

--- a/app/javascript/components/Schedule/ScheduleSlot.js
+++ b/app/javascript/components/Schedule/ScheduleSlot.js
@@ -60,7 +60,7 @@ class ScheduleSlot extends Component {
   }
 
   render() {
-    const { slot, ripTime, startTime, sessions, tracks } = this.props
+    const { slot, ripTime, startTime, sessions, tracks, csrf, unscheduledSessions } = this.props
     
     const slotStartTime = ripTime(slot.start_time)
     const slotEndTime = ripTime(slot.end_time)
@@ -72,9 +72,10 @@ class ScheduleSlot extends Component {
       background
     }
 
+    let matchedSession
     let session = <Fragment/>
     if (slot.program_session_id) {
-      let matchedSession = sessions.find(
+      matchedSession = sessions.find(
         session => session.id === slot.program_session_id
       )
       session = <ProgramSession session={matchedSession} onDrag={this.onDrag} tracks={tracks} />
@@ -92,7 +93,7 @@ class ScheduleSlot extends Component {
         onClick={this.showModal}
       >
         {session}
-        {this.state.modalShown && <TimeSlotModal programSession={this.props.slot.program_session_id}/>}
+        {this.state.modalShown && <TimeSlotModal csrf={csrf} slot={this.props.slot} matchedSession={matchedSession} unscheduledSessions={unscheduledSessions} tracks={tracks}/>}
       </div>
     )
   }
@@ -105,7 +106,8 @@ ScheduleSlot.propTypes = {
   changeDragged: PropTypes.func,
   draggedSession: PropTypes.object,
   handleMoveSessionResponse: PropTypes.func,
-  tracks: PropTypes.array
+  tracks: PropTypes.array,
+  unscheduledSessions: PropTypes.array
 }
 
 export default ScheduleSlot

--- a/app/javascript/components/Schedule/ScheduleSlot.js
+++ b/app/javascript/components/Schedule/ScheduleSlot.js
@@ -66,7 +66,7 @@ class ScheduleSlot extends Component {
   }
 
   render() {
-    const { slot, ripTime, startTime, sessions, tracks, csrf, unscheduledSessions, handleMoveSessionResponse } = this.props
+    const { slot, ripTime, startTime, sessions, tracks, csrf, unscheduledSessions, handleMoveSessionResponse, sessionFormats } = this.props
     
     const slotStartTime = ripTime(slot.start_time)
     const slotEndTime = ripTime(slot.end_time)
@@ -108,6 +108,7 @@ class ScheduleSlot extends Component {
           closeModal={this.closeModal}
           sessions={sessions}
           handleMoveSessionResponse={handleMoveSessionResponse}
+          sessionFormats={sessionFormats}
         />}
       </div>
     )

--- a/app/javascript/components/Schedule/ScheduleSlot.js
+++ b/app/javascript/components/Schedule/ScheduleSlot.js
@@ -2,13 +2,15 @@ import React, { Component, Fragment } from "react"
 import PropTypes from "prop-types"
 
 import ProgramSession from './ProgramSession'
+import TimeSlotModal from './TimeSlotModal'
 import { patchTimeSlot } from "../../apiCalls"
 
 class ScheduleSlot extends Component {
   constructor(props) {
     super(props)
     this.state = {
-      hoverDrag: false
+      hoverDrag: false,
+      modalShown: false
     }
   }
   
@@ -53,6 +55,10 @@ class ScheduleSlot extends Component {
     this.props.changeDragged(Object.assign(programSession, {slot: this.props.slot}))
   }
 
+  showModal = () => {
+    this.setState({modalShown: true})
+  }
+
   render() {
     const { slot, ripTime, startTime, sessions, tracks } = this.props
     
@@ -83,8 +89,10 @@ class ScheduleSlot extends Component {
         onDragOver={e => this.onDragOver(e)}
         onDragLeave={e => this.onDragLeave(e)}
         onDrop={() => this.onDrop(slot)}
+        onClick={this.showModal}
       >
         {session}
+        {this.state.modalShown && <TimeSlotModal programSession={this.props.slot.program_session_id}/>}
       </div>
     )
   }

--- a/app/javascript/components/Schedule/ScheduleSlot.js
+++ b/app/javascript/components/Schedule/ScheduleSlot.js
@@ -29,7 +29,8 @@ class ScheduleSlot extends Component {
     this.setState({ hoverDrag: false})
   }
 
-  onDrop = slot => {
+  onDrop = (slot, e) => {
+    e.preventDefault()
     const session = this.props.draggedSession
     const { csrf, handleMoveSessionResponse, changeDragged } = this.props
     
@@ -44,7 +45,7 @@ class ScheduleSlot extends Component {
       .then((response) => response.json())
       .then(data => {
         const { errors } = data
-        
+
         if (errors) {
           this.props.showErrors(errors)
           return
@@ -121,7 +122,7 @@ class ScheduleSlot extends Component {
         key={slot.id}
         onDragOver={e => this.onDragOver(e)}
         onDragLeave={e => this.onDragLeave(e)}
-        onDrop={() => this.onDrop(slot)}
+        onDrop={(e) => this.onDrop(slot, e)}
         onClick={this.showModal}
       >
         {session || timeSlotInfo}

--- a/app/javascript/components/Schedule/TimeSlotInfo.js
+++ b/app/javascript/components/Schedule/TimeSlotInfo.js
@@ -1,0 +1,35 @@
+import React, { Component } from "react"
+import PropTypes from "prop-types"
+
+class TimeSlotInfo extends Component {
+  constructor(props) {
+    super(props)
+  }
+  
+  render() {
+    const {slot, tracks} = this.props
+
+    const slotTrack = tracks.find(track => track.id === slot.track_id)
+
+    const bkgColor = slotTrack ? slotTrack.color : 'unset'
+    const trackName = slotTrack ? slotTrack.name : ''
+
+    return(
+      <div className='slot_info_card' >
+        <div className='card_header' style={{'backgroundColor': bkgColor}}>{trackName}</div>
+        <div className='card_body'>
+          <p>{slot.title}</p>
+        </div>
+      </div>
+    )
+  }
+}
+
+export default TimeSlotInfo
+
+TimeSlotInfo.propTypes = {
+  slot: PropTypes.object,
+  tracks: PropTypes.array
+}
+
+TimeSlotInfo.defaultProps = {tracks: []}

--- a/app/javascript/components/Schedule/TimeSlotModal.js
+++ b/app/javascript/components/Schedule/TimeSlotModal.js
@@ -125,7 +125,7 @@ class TimeSlotModal extends Component {
       </label>
       <label>
         Description:
-        <input
+        <textarea
           type='text'
           name='description'
           value={this.props.description}
@@ -137,6 +137,9 @@ class TimeSlotModal extends Component {
     return (
       <div className='modal-container'>
         <div className='bulk-modal'>
+          <div className='modal-header' >
+            <h3>Edit Time Slot</h3>
+          </div>
           <div className='modal-body'>
             <label>
               Program Session

--- a/app/javascript/components/Schedule/TimeSlotModal.js
+++ b/app/javascript/components/Schedule/TimeSlotModal.js
@@ -1,0 +1,33 @@
+import React, { Component } from "react"
+import PropTypes from "prop-types"
+
+class TimeSlotModal extends Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+
+    }
+  }
+
+  componentDidMount() {
+    if ( this.props.programSession ) {
+      console.log('TEST')
+    }
+  }
+
+  render() {
+    return (
+      <div className='modal-container'>
+        <div className='bulk-modal'>
+          
+        </div>
+      </div>
+    )
+  }
+}
+
+TimeSlotModal.propTypes = {
+
+}
+
+export default TimeSlotModal

--- a/app/javascript/components/Schedule/TimeSlotModal.js
+++ b/app/javascript/components/Schedule/TimeSlotModal.js
@@ -5,21 +5,47 @@ class TimeSlotModal extends Component {
   constructor(props) {
     super(props)
     this.state = {
-
+      sessionSelected: this.props.matchedSession 
+      ? this.props.matchedSession.title
+      : ''
     }
   }
 
   componentDidMount() {
-    if ( this.props.programSession ) {
-      console.log('TEST')
-    }
+    const { csrf, slot, matchedSession } = this.props
+    console.log(slot, matchedSession)
+  }
+
+  changeSession(e) {
+    this.setState({ sessionSelected: e.target.value })
   }
 
   render() {
+    const { slot, matchedSession, unscheduledSessions, tracks } = this.props
+    let sessionOptions
+    if (matchedSession) {
+      sessionOptions = [matchedSession, ...unscheduledSessions]
+    } else {
+      sessionOptions = [...unscheduledSessions]
+    }
+    sessionOptions = sessionOptions.map(session => (
+      <option key={'session ' + session.title} value={session}>{session.title}</option>
+    ))
+
     return (
       <div className='modal-container'>
         <div className='bulk-modal'>
-          
+          <div className='modal-body'>
+            <label>
+              Program Session
+              <select
+                className='full-width-input'
+                value={this.state.sessionSelected}
+                onChange={this.changeSession} >
+                {sessionOptions}
+              </select>
+            </label>
+          </div>
         </div>
       </div>
     )

--- a/app/javascript/components/Schedule/TimeSlotModal.js
+++ b/app/javascript/components/Schedule/TimeSlotModal.js
@@ -39,7 +39,7 @@ class TimeSlotModal extends Component {
   }
 
   render() {
-    const { slot, matchedSession, unscheduledSessions, tracks} = this.props
+    const { slot, matchedSession, unscheduledSessions, tracks, sessionFormats} = this.props
     const { sessionSelected } = this.state
     let sessionOptions
     if (sessionSelected) {
@@ -67,6 +67,10 @@ class TimeSlotModal extends Component {
         <label>
           Abstract:
           <p>{sessionSelected.abstract}</p>
+        </label>
+        <label>
+          Recommended duration:
+          <p>{sessionFormats.find(s => s.id === sessionSelected.session_format_id).duration + ' minutes'}</p>
         </label>
       </>
     }

--- a/app/javascript/components/Schedule/TimeSlotModal.js
+++ b/app/javascript/components/Schedule/TimeSlotModal.js
@@ -110,7 +110,7 @@ class TimeSlotModal extends Component {
         <select name='track' value={this.props.track} onChange={this.props.updateSlot}>
           <option value=''></option>
           {tracks.map(t => (
-            <option value={t.id}>{t.name}</option>
+            <option key={t.id} value={t.id}>{t.name}</option>
           ))}
         </select>
       </label>

--- a/app/javascript/components/Schedule/TimeSlotModal.js
+++ b/app/javascript/components/Schedule/TimeSlotModal.js
@@ -27,9 +27,16 @@ class TimeSlotModal extends Component {
 
   saveChanges = () => {
     const { sessionSelected } = this.state
-    const { csrf, slot, closeModal, handleMoveSessionResponse } = this.props
+    const { csrf, closeModal, handleMoveSessionResponse, title, track, presenter, description } = this.props
     
-    patchTimeSlot(slot, sessionSelected, csrf)
+    let slot
+    if (!sessionSelected) {
+      slot = Object.assign(this.props.slot, {title, track_id: track, presenter, description})
+    } else {
+      slot = this.props.slot
+    }
+    
+    patchTimeSlot(slot, (sessionSelected || null), csrf)
       .then(response => response.json())
       .then(data => {
         const { sessions, slots, unscheduled_sessions } = data
@@ -39,8 +46,21 @@ class TimeSlotModal extends Component {
   }
 
   render() {
-    const { slot, matchedSession, unscheduledSessions, tracks, sessionFormats} = this.props
+    const { 
+      slot, 
+      matchedSession, 
+      unscheduledSessions, 
+      tracks, 
+      sessionFormats, 
+      title, 
+      track, 
+      presenter, 
+      description, 
+      updateSlot 
+    } = this.props
+
     const { sessionSelected } = this.state
+
     let sessionOptions
     if (sessionSelected) {
       sessionOptions = matchedSession 
@@ -75,6 +95,45 @@ class TimeSlotModal extends Component {
       </>
     }
 
+    let timeSlotForm = <>
+      <label>
+        Title:
+        <input
+          type='text'
+          name='title'
+          value={this.props.title}
+          onChange={this.props.updateSlot}
+        />
+      </label>
+      <label>
+        Track:
+        <select name='track' value={this.props.track} onChange={this.props.updateSlot}>
+          <option value=''></option>
+          {tracks.map(t => (
+            <option value={t.id}>{t.name}</option>
+          ))}
+        </select>
+      </label>
+      <label>
+        Presenter:
+        <input
+          type='text'
+          name='presenter'
+          value={this.props.presenter}
+          onChange={this.props.updateSlot}
+        />
+      </label>
+      <label>
+        Description:
+        <input
+          type='text'
+          name='description'
+          value={this.props.description}
+          onChange={this.props.updateSlot}
+        />
+      </label>
+    </>
+
     return (
       <div className='modal-container'>
         <div className='bulk-modal'>
@@ -87,7 +146,7 @@ class TimeSlotModal extends Component {
                 {sessionOptions}
               </select>
             </label>
-            {sessionSelected ? sessionInfo :<></>}
+            {sessionSelected ? sessionInfo : timeSlotForm}
           </div>
           <div className='modal-footer'>
             <button

--- a/app/javascript/components/Schedule/TimeSlotModal.js
+++ b/app/javascript/components/Schedule/TimeSlotModal.js
@@ -18,7 +18,11 @@ class TimeSlotModal extends Component {
 
   changeSession = (e) => {
     let session = this.props.sessions.find(s => s.title === e.target.value )
-    this.setState({ sessionSelected: session })
+    if (!session) {
+      this.setState({ sessionSelected: '' })
+    } else {
+      this.setState({ sessionSelected: session })
+    }
   }
 
   close = () => {
@@ -65,7 +69,7 @@ class TimeSlotModal extends Component {
     if (sessionSelected) {
       sessionOptions = matchedSession 
         ? [matchedSession, ...unscheduledSessions]
-        : [sessionSelected, ...unscheduledSessions.filter(s => s.id !== sessionSelected.id)]
+        : [{title: ''}, sessionSelected, ...unscheduledSessions.filter(s => s.id !== sessionSelected.id)]
     } else {
       sessionOptions = [{title: ''}, ...unscheduledSessions]
     }
@@ -145,7 +149,8 @@ class TimeSlotModal extends Component {
               Program Session
               <select
                 value={this.state.sessionSelected.title}
-                onChange={this.changeSession} >
+                onChange={this.changeSession} 
+              >
                 {sessionOptions}
               </select>
             </label>

--- a/app/javascript/components/Schedule/UnscheduledArea.js
+++ b/app/javascript/components/Schedule/UnscheduledArea.js
@@ -51,7 +51,6 @@ class UnscheduledArea extends Component {
     const { sessions, unscheduledSessions, tracks } = this.props
     const { searchInput, isHidden } = this.state
     let display = isHidden ? "none" : ""
-
     let filteredSessions = unscheduledSessions.filter(session => {
       const titleMatch =  session.title.toLowerCase().includes(searchInput.toLowerCase()) 
       let trackMatch 

--- a/app/javascript/components/Schedule/UnscheduledArea.js
+++ b/app/javascript/components/Schedule/UnscheduledArea.js
@@ -34,7 +34,8 @@ class UnscheduledArea extends Component {
     e.preventDefault()
   }
 
-  onDrop = () => {
+  onDrop = (e) => {
+    e.preventDefault()
     const { draggedSession, csrf, tracks } = this.props
 
     patchTimeSlot(draggedSession.slot, null, csrf)
@@ -69,7 +70,7 @@ class UnscheduledArea extends Component {
     return (
       <div
         className="unscheduled_area"
-        onDrop={this.onDrop}
+        onDrop={(e) => this.onDrop(e)}
         onDragOver={e => this.onDragOver(e)}
       >
         <div className="header_wrapper" onClick={this.changeHiddenState}>

--- a/app/views/staff/grids/schedule.json.jbuilder
+++ b/app/views/staff/grids/schedule.json.jbuilder
@@ -1,7 +1,7 @@
 
 json.rooms current_event.rooms, :id, :name
 json.days (1..current_event.days).to_a
-json.slots current_event.time_slots, :conference_day, :id, :update_path, :start_time, :end_time, :program_session_id, :track_id, :room_id
+json.slots current_event.time_slots
 json.sessions current_event.program_sessions
 json.unscheduledSessions current_event.program_sessions.unscheduled
 json.counts EventStats.new(current_event).schedule_counts


### PR DESCRIPTION
Time slots are now clickable, giving the user access to a modal that can do one of the following: 

1. The modal allows for scheduling of unscheduled sessions in that slot via a modal dropdown, with an overview of the unscheduled session before confirming. 
2. If a time slot is unscheduled, a user may edit the time slot directly through the modal. Adding a description, title, track, and presenter.