### PR TITLE
303 duplicate time slots

### DIFF
--- a/app/assets/stylesheets/modules/_schedule.scss
+++ b/app/assets/stylesheets/modules/_schedule.scss
@@ -720,7 +720,7 @@ input[type=number]::-webkit-outer-spin-button {
           font-weight: normal;
         }
 
-        .required {
+        .required, .error {
           color: #751317
         }
 

--- a/app/controllers/staff/grids/bulk_time_slots_controller.rb
+++ b/app/controllers/staff/grids/bulk_time_slots_controller.rb
@@ -27,7 +27,7 @@ class Staff::Grids::BulkTimeSlotsController < Staff::ApplicationController
     @schedule = Schedule.new(current_event)
 
     respond_to do |format|
-      format.json { render json: { slots: current_event.time_slots }, status: :ok }
+      fuormat.json { render json: { slots: current_event.time_slots }, status: :ok }
     end
   rescue StandardError => e
     render json: { slots: current_event.time_slots, errors: ["An error occured when attempting to bulk create"] }, status: 500

--- a/app/controllers/staff/grids/bulk_time_slots_controller.rb
+++ b/app/controllers/staff/grids/bulk_time_slots_controller.rb
@@ -27,7 +27,7 @@ class Staff::Grids::BulkTimeSlotsController < Staff::ApplicationController
     @schedule = Schedule.new(current_event)
 
     respond_to do |format|
-      fuormat.json { render json: { slots: current_event.time_slots }, status: :ok }
+      format.json { render json: { slots: current_event.time_slots }, status: :ok }
     end
   rescue StandardError => e
     render json: { slots: current_event.time_slots, errors: ["An error occured when attempting to bulk create"] }, status: 500

--- a/app/javascript/components/Schedule.js
+++ b/app/javascript/components/Schedule.js
@@ -109,7 +109,7 @@ class Schedule extends Component {
         let sameDaySameRoom = s.room_id === parseInt(ps.room) && s.conference_day === ps.day
 
         if (sameDaySameRoom) {
-          let timeConflict = ps.startTime > this.ripTime(s.start_time) && ps.startTime < this.ripTime(s.end_time) || ps.endTime > this.ripTime(s.start_time) && ps.startTime < this.ripTime(s.end_time)
+          let timeConflict = this.determineTimeConflict(ps, s)
           
           if (timeConflict) {
             conflicts.push(s)
@@ -122,7 +122,7 @@ class Schedule extends Component {
         let sameDaySameRoom = parseInt(preview.room) === parseInt(ps.room) && preview.day === ps.day
 
         if (sameDaySameRoom) {
-          let timeConflict = ps.startTime > preview.startTime && ps.startTime < preview.endTime || ps.endTime > preview.startTime && ps.startTime < preview.endTime
+          let timeConflict = this.determineTimeConflict(ps, preview)
           
           if (timeConflict) {
             conflicts.push(Object.assign(preview, { previewConflict: true }))
@@ -133,6 +133,14 @@ class Schedule extends Component {
     })
 
     return conflicts
+  }
+
+  determineTimeConflict = (previewSlot, compareSlot) => {
+    if (compareSlot.endTime) {
+      return previewSlot.startTime > compareSlot.startTime && previewSlot.startTime < compareSlot.endTime || previewSlot.endTime > compareSlot.startTime && previewSlot.startTime < compareSlot.endTime
+    } else {
+      return previewSlot.startTime > this.ripTime(compareSlot.start_time) && previewSlot.startTime < this.ripTime(compareSlot.end_time) || previewSlot.endTime > this.ripTime(compareSlot.start_time) && previewSlot.startTime < this.ripTime(compareSlot.end_time)
+    }
   }
 
   handleConflicts = (conflicts, bulkTimeSlotModalEditState) => {

--- a/app/javascript/components/Schedule.js
+++ b/app/javascript/components/Schedule.js
@@ -144,7 +144,7 @@ class Schedule extends Component {
       let message
 
       if (c.previewConflict) {
-        message = `You attempted to make two new time slots that overlap. The overlap occurs on Day ${c.conference_day} at the ${rooms.find(r => r.id == parseInt(c.room)).name} location.`
+        message = `You attempted to make two new time slots that overlap. The overlap occurs on Day ${c.day} at the ${rooms.find(r => r.id == parseInt(c.room)).name} location.`
       } else {
         message = `You attempted to preview a slot which overlaps an existing slot. The overlap involves a previously existing slot on Day ${c.conference_day} at the ${rooms.find(r => r.id == c.room_id).name} location, between  ${c.start_time.split('T')[1].split('.')[0]} and ${c.end_time.split('T')[1].split('.')[0]}`
       }

--- a/app/javascript/components/Schedule.js
+++ b/app/javascript/components/Schedule.js
@@ -109,8 +109,7 @@ class Schedule extends Component {
         let sameDaySameRoom = s.room_id === parseInt(ps.room) && s.conference_day === ps.day
 
         if (sameDaySameRoom) {
-          let timeConflict = this.determineTimeConflict(ps, s)
-          
+          let timeConflict = this.determineTimeConflict(ps, this.ripTime(s.start_time), this.ripTime(s.end_time))
           if (timeConflict) {
             conflicts.push(s)
           }
@@ -122,7 +121,7 @@ class Schedule extends Component {
         let sameDaySameRoom = parseInt(preview.room) === parseInt(ps.room) && preview.day === ps.day
 
         if (sameDaySameRoom) {
-          let timeConflict = this.determineTimeConflict(ps, preview)
+          let timeConflict = this.determineTimeConflict(ps, preview.startTime, preview.endTime)
           
           if (timeConflict) {
             conflicts.push(Object.assign(preview, { previewConflict: true }))
@@ -135,12 +134,8 @@ class Schedule extends Component {
     return conflicts
   }
 
-  determineTimeConflict = (previewSlot, compareSlot) => {
-    if (compareSlot.endTime) {
-      return previewSlot.startTime > compareSlot.startTime && previewSlot.startTime < compareSlot.endTime || previewSlot.endTime > compareSlot.startTime && previewSlot.startTime < compareSlot.endTime
-    } else {
-      return previewSlot.startTime > this.ripTime(compareSlot.start_time) && previewSlot.startTime < this.ripTime(compareSlot.end_time) || previewSlot.endTime > this.ripTime(compareSlot.start_time) && previewSlot.startTime < this.ripTime(compareSlot.end_time)
-    }
+  determineTimeConflict = (previewSlot, compareStartTime, compareEndTime) => {
+    return previewSlot.startTime > compareStartTime && previewSlot.startTime < compareEndTime || previewSlot.endTime > compareStartTime && previewSlot.startTime < compareEndTime
   }
 
   handleConflicts = (conflicts, bulkTimeSlotModalEditState) => {

--- a/app/javascript/components/Schedule.js
+++ b/app/javascript/components/Schedule.js
@@ -154,7 +154,7 @@ class Schedule extends Component {
 
     let conflicts = this.findTimeSlotConflicts(previewSlots)
 
-    if (conflicts) {
+    if (conflicts.length > 0) {
       this.handleConflicts(conflicts, bulkTimeSlotModalEditState)
     } else {
       this.setState({

--- a/app/javascript/components/Schedule.js
+++ b/app/javascript/components/Schedule.js
@@ -116,6 +116,19 @@ class Schedule extends Component {
           }
         }
       })
+
+      previewSlots.forEach(preview => {
+        if (Object.is(ps, preview)) { return }
+        let sameDaySameRoom = parseInt(preview.room) === parseInt(ps.room) && preview.day === ps.day
+
+        if (sameDaySameRoom) {
+          let timeConflict = ps.startTime > preview.startTime && ps.startTime < preview.endTime || ps.endTime > preview.startTime && ps.startTime < preview.endTime
+          
+          if (timeConflict) {
+            conflicts.push(Object.assign(preview, { previewConflict: true }))
+          }
+        }
+      })
       
     })
 
@@ -128,11 +141,18 @@ class Schedule extends Component {
     let errorMessages = []
 
     conflicts.forEach(c => {
-      let message = `You attempted to preview a slot which overlaps an existing slot. The overlap involves a previously existing slot on Day ${c.conference_day} at the ${rooms.find(r => r.id == c.room_id).name} location, between  ${c.start_time.split('T')[1].split('.')[0]} and ${c.end_time.split('T')[1].split('.')[0]}`
+      let message
 
+      if (c.previewConflict) {
+        message = `You attempted to make two new time slots that overlap. The overlap occurs on Day ${c.conference_day} at the ${rooms.find(r => r.id == parseInt(c.room)).name} location.`
+      } else {
+        message = `You attempted to preview a slot which overlaps an existing slot. The overlap involves a previously existing slot on Day ${c.conference_day} at the ${rooms.find(r => r.id == c.room_id).name} location, between  ${c.start_time.split('T')[1].split('.')[0]} and ${c.end_time.split('T')[1].split('.')[0]}`
+      }
+       
       errorMessages.push(message)
     })
 
+    errorMessages =  [...new Set(errorMessages)];
     this.setState({
       errorMessages,
       bulkTimeSlotModalEditState,

--- a/app/javascript/components/Schedule/Alert.js
+++ b/app/javascript/components/Schedule/Alert.js
@@ -2,23 +2,15 @@ import React, { Component, Fragment } from "react"
 import PropTypes from "prop-types"
 
 class Alert extends Component {
-  formatedMessages = messages => {
-    let message = ''
-
-    messages.forEach(msg => {
-      message += `${msg}. `
-    })
-
-    return message
-  }
-
   render() {
     const messages = this.props.messages;
 
     return (
       <div className="scheduling-error alert alert-danger">
         <button className='close' onClick={this.props.onClose}> &times; </button>
-        { this.formatedMessages(messages) }
+        { messages.map(message => {
+          return <p>{message}</p>
+        }) }
       </div>
     )
   }

--- a/app/javascript/components/Schedule/BulkCreateModal.js
+++ b/app/javascript/components/Schedule/BulkCreateModal.js
@@ -8,7 +8,8 @@ class BulkCreateModal extends Component {
       day: 1,
       rooms: [],
       startTimes: '',
-      duration: ''
+      duration: '',
+      timeError: false
     }
   }
 
@@ -31,7 +32,34 @@ class BulkCreateModal extends Component {
 
   changeInput = (e) => {
     const name = e.target.name
-    this.setState({[name]: e.target.value})
+    this.setState({[name]: e.target.value}, () => {
+      name === 'startTimes' && this.validateTimes()
+    })
+  }
+
+  validateTimes = () => {
+    const { startTimes } = this.state
+    let valid = true
+    startTimes.split(',').forEach(time => {
+      const cleanedTime = time.replace(/\s/g, '')
+      if (time.includes(':')) {
+        const validTime = /^([0-1]?[0-9]|2[0-3]):([0-5][0-9])(:[0-5][0-9])?$/.test(cleanedTime)
+  
+        if (!validTime) {
+          valid = false
+        } 
+      } else {
+        if ( parseInt(cleanedTime) > 24 || parseInt(cleanedTime) < 0 ) {
+          valid = false
+        }
+      }
+    })
+
+    if (!valid) {
+      this.setState({timeError: true})
+    } else {
+      this.setState({timeError: false})
+    }
   }
 
   previewSlots = () => {
@@ -75,6 +103,7 @@ class BulkCreateModal extends Component {
 
   render() {
     let { sessionFormats, closeBulkTimeSlotModal, counts } = this.props
+    let { timeError, day, startTimes, duration } = this.state
 
     const days = Object.keys(counts)
     const dayOptions = days.map(day => (
@@ -117,9 +146,9 @@ class BulkCreateModal extends Component {
     })
 
     const previewDisabled = () => {
-      const { rooms, startTimes, duration } = this.state
+      const { rooms, startTimes, duration, timeError } = this.state
 
-      return rooms.length < 1 || startTimes.length < 1 || duration.length < 1
+      return rooms.length < 1 || startTimes.length < 1 || duration.length < 1 || timeError
     }
 
     return (
@@ -133,7 +162,7 @@ class BulkCreateModal extends Component {
               Day
               <select 
                 className='full-width-input' 
-                value={this.state.day} 
+                value={day} 
                 onChange={this.changeDay} >
                   {dayOptions}
               </select>
@@ -146,12 +175,13 @@ class BulkCreateModal extends Component {
             <label>
               Start Times
               {denoteRequired('startTimes')}
+              {timeError && <p className='error'>Please only enter times between 0:00 and 23:59</p>}
               <div>
                 <input 
                   className='start-times full-width-input'
                   type='text'
                   name='startTimes'
-                  value={this.state.startTimes}
+                  value={startTimes}
                   onChange={this.changeInput}
                   placeholder='ex: 10:00, 11:00, 13:00'
                 />
@@ -165,7 +195,7 @@ class BulkCreateModal extends Component {
                   className='start-times minutes-input'
                   type='number'
                   name='duration'
-                  value={this.state.duration}
+                  value={duration}
                   onChange={this.changeInput}
                 />
                 <select 

--- a/app/models/time_slot.rb
+++ b/app/models/time_slot.rb
@@ -26,6 +26,11 @@ class TimeSlot < ApplicationRecord
 
   validates :room_id, :conference_day, presence: true
 
+  validates :start_time, {uniqueness: {
+    scope: [:room, :conference_day],
+    message: "is already taken for that room and day combination."
+  }}
+
   def serializable_hash(options)
     super(methods: :update_path)
   end

--- a/spec/factories/time_slots.rb
+++ b/spec/factories/time_slots.rb
@@ -3,8 +3,8 @@
 FactoryBot.define do
   factory :time_slot do
     conference_day { 1 }
-    start_time { "2014-01-31 10:41:58" }
-    end_time { "2014-01-31 11:41:58" }
+    start_time { "10:41 am" }
+    end_time { "11:41 am" }
     title { "MyText" }
     description { "MyText" }
     presenter { "MyText" }

--- a/spec/models/time_slot_spec.rb
+++ b/spec/models/time_slot_spec.rb
@@ -1,4 +1,15 @@
 require 'rails_helper'
 
 describe TimeSlot do
+  describe 'validations' do 
+    it 'ensures unique start time for room and day' do
+      original = create(:time_slot) 
+      duplicate = build(:time_slot, room: original.room) 
+      expect(duplicate).to_not be_valid
+      
+      duplicate.conference_day += 1
+
+      expect(duplicate).to be_valid
+    end
+  end
 end


### PR DESCRIPTION
This PR includes both [#303 -- Prevent duplicate time slots](https://featurecompleteapp.com/p/ruby-central/cfp-app/work/303) and [#301 -- Limit bulk generate hours options](https://featurecompleteapp.com/p/ruby-central/cfp-app/work/301)

### 303
303 has a couple of layers of checks, one robust one on the front end that prevents generation from the bulk generate button on the grid view, and a validation on the Time Slot model which prevents two time slots starting at the same time on the same day and in the same "room". This is very helpful on the [time slots page](https://cfp-app-dev.herokuapp.com/events/seedconf/staff/schedule/time_slots).

The front end validation checks also that there is no overlap of time slots being proposed, for example, a time slot of 8:45-9:15 am would not be allowed if there was a 9:00-9:30am slot already. It also checks that two new proposed time slots do not overlap in the bulk generate.
![image](https://user-images.githubusercontent.com/33355716/60602753-ab298100-9d71-11e9-8253-1bad62fba929.png)

### 301
This was a quick Regex check that ensures invalid times are not entered. 

[![Image from Gyazo](https://i.gyazo.com/8d3b3ad9dc45e0b49e6b88479031ea61.gif)](https://gyazo.com/8d3b3ad9dc45e0b49e6b88479031ea61)